### PR TITLE
Alpha0.5

### DIFF
--- a/post_install.py
+++ b/post_install.py
@@ -1,9 +1,5 @@
 import os, shutil, glob, sys
-<<<<<<< HEAD
-from distutils.sysconfig import get_python_lib
-=======
 from sysconfig import get_path
->>>>>>> c329e87ea59dee97a0907c23075b26bd9088635b
 from glob import glob
 from pkgutil import get_loader
 from setuptools import setup
@@ -11,7 +7,6 @@ from subprocess import call
 
 def get_library_location(package):
     # get abs path of a package in the library, rather than locally
-
     library_package_paths = glob(os.path.join(get_path('platlib'), '*'))
     sys.path = library_package_paths + sys.path
     package_path = get_loader(package).filename
@@ -37,9 +32,10 @@ os.waitpid(pid, 0)
 # move created database files to your library's package directory
 db_files = glob(os.path.join(script_location, 'worm.db*'))
 for db_file in db_files:
-  print('copying {} to {}'.format(db_file, package_location))
-  new_location = os.path.join(package_location, os.path.basename(db_file))
-  shutil.copy(db_file, package_location)
-  os.chmod(new_location, 0777)
+    print('copying {} to {}'.format(db_file, package_location))
+    new_location = os.path.join(package_location, os.path.basename(db_file))
+    shutil.copy(db_file, package_location)
+    os.chmod(new_location, 0777)
 # change directory owner to allow writing and reading from db in that dir
 os.chown(package_location, user_id, -1)
+


### PR DESCRIPTION
As suggested in #9, I am recommending that alpha0.5 be merged into master. A summary of the changes between alpha0.5 and master is below. Comments, criticisms, and concerns are welcome.

Alpha0.5:

-  provides a declarative syntax for reading and writing properties. Described in the [documentation](http://pyopenworm.readthedocs.org/en/alpha0.5/#pyopenworm).
-  offers an extensible means of defining [new objects](http://pyopenworm.readthedocs.org/en/alpha0.5/making_dataObjects.html) using normal Python classes. New objects and types of objects can be added to shared databases while still being accessible to library versions which lack definition of these additional classes and objects.
-  features [updated documentation](http://pyopenworm.readthedocs.org/en/alpha0.5/making_dataObjects.html) on the changes.
-  enables higher-order statements to be made about the [properties](http://pyopenworm.readthedocs.org/en/alpha0.5/index.html#PyOpenWorm.dataObject.Property) of an object and the relationships between objects.
-  comes with [initial data](https://github.com/mwatts15/OpenWormData) based on pre-existing data sources
-  includes unit tests which cover the core functionality