### PR TITLE
Hiding iterators returned from Property `get`

### DIFF
--- a/PyOpenWorm/cell.py
+++ b/PyOpenWorm/cell.py
@@ -77,6 +77,7 @@ class Cell(DataObject):
 
         if name:
             self.name(name)
+
         if lineageName:
             self.lineageName(lineageName)
 
@@ -129,7 +130,7 @@ class Cell(DataObject):
         """
         import re
         try:
-            ln = next(self.lineageName())
+            ln = self.lineageName()
             x = re.split("[. ]", ln)
             return x[0]
         except:
@@ -137,7 +138,7 @@ class Cell(DataObject):
 
     def daughterOf(self):
         """ Get the parent of this cell """
-        ln = next(self.lineageName())
+        ln = self.lineageName()
         parent_ln = ln[:-1]
         return Cell(lineageName=parent_ln)
 
@@ -147,7 +148,7 @@ class Cell(DataObject):
         # custom patterns to the load query.
 
         # hackish. just query for the possible children lineage names...
-        ln = next(self.lineageName())
+        ln = self.lineageName()
         possible_child_lns = [ln + "a", ln + "v",
                               ln + "p", ln + "r",
                               ln + "l", ln + "d"]
@@ -169,14 +170,14 @@ class Cell(DataObject):
 
             if len(self.name.v) > 0:
                 # name is already set, so we can make an identifier from it
-                n = next(self.name())
+                n = self.name()
                 return self.make_identifier(n)
             else:
                 return ident
         else:
             if len(self.name.v) > 0:
                 # name is already set, so we can make an identifier from it
-                n = next(self.name())
+                n = self.name.one()
                 return self.make_identifier(n)
             else:
                 return ident

--- a/PyOpenWorm/configure.py
+++ b/PyOpenWorm/configure.py
@@ -99,7 +99,6 @@ class Configure(object):
         elif default:
             return default
         else:
-            print self._properties
             raise KeyError(pname)
 
 class Configureable(object):

--- a/PyOpenWorm/dataObject.py
+++ b/PyOpenWorm/dataObject.py
@@ -280,7 +280,7 @@ class DataObject(DataUser):
         return cls._create_property(*args,property_type='ObjectProperty',**kwargs)
 
     @classmethod
-    def _create_property(cls, linkName, owner, property_type, value_type=False):
+    def _create_property(cls, linkName, owner, property_type, value_type=False, multiple=False):
         #XXX This should actually get called for all of the properties when their owner
         #    classes are defined.
         #    The initialization, however, must happen with the owner object's creation
@@ -298,8 +298,7 @@ class DataObject(DataUser):
                 value_rdf_type = value_type.rdf_type
             else:
                 value_rdf_type = False
-
-            c = type(property_class_name,(SimpleProperty,),dict(linkName=linkName, property_type=property_type, value_rdf_type=value_rdf_type, owner_type=owner_class))
+            c = type(property_class_name,(SimpleProperty,),dict(linkName=linkName, property_type=property_type, value_rdf_type=value_rdf_type, owner_type=owner_class, multiple=multiple))
             _DataObjects[property_class_name] = c
             c.register()
 
@@ -307,6 +306,8 @@ class DataObject(DataUser):
 
     @classmethod
     def register(cls):
+        """ Registers the class as a DataObject to be included in the configured rdf graph
+        """
         # NOTE: This expects that configuration has been read in and that the database is available
         assert(issubclass(cls, DataObject))
         _DataObjects[cls.__name__] = cls
@@ -319,6 +320,7 @@ class DataObject(DataUser):
         """ Load in data from the database. Derived classes should override this for their own data structures.
 
         ``load()`` returns an iterable object which yields DataObjects which have the same class as the object and have, for the Properties set, the same values
+
         :param self: An object which limits the set of objects which can be returned. Should have the configuration necessary to do the query
         """
         # 'loading' an object _always_ means doing a query. When we do the query, we identify all of the result sets that can make objects in the current
@@ -386,6 +388,12 @@ class DataObject(DataUser):
         """ Remove this object from the data store. """
         self.retract_statements(self.graph_pattern(query=True))
 
+    def __getitem__(self, x):
+        try:
+            return DataUser.__getitem__(self, x)
+        except KeyError:
+            raise Exception("You attempted to get the value `%s' from `%s'. It isn't here. Perhaps you misspelled the name of a Property?" % (x, self))
+
 # Define a property by writing the get
 class Property(DataObject):
     """ Store a value associated with a DataObject
@@ -407,6 +415,10 @@ class Property(DataObject):
             owner.name
 
     """
+
+    # Indicates whether the Property is multivalued
+    multiple = False
+
     def __init__(self, name=False, owner=False, **kwargs):
         DataObject.__init__(self, **kwargs)
         self.owner = owner
@@ -421,6 +433,10 @@ class Property(DataObject):
     def get(self,*args):
         """ Get the things which are on the other side of this property
 
+        The return value must be iterable. For a ``get`` that just returns
+        a single value, an easy way to make an iterable is to wrap the
+        value in a tuple like ``(value,)``.
+
         Derived classes must override.
         """
         # This should run a query or return a cached value
@@ -432,25 +448,48 @@ class Property(DataObject):
         """
         # This should set some values and call DataObject.save()
         raise NotImplementedError()
+
     def one(self):
+        """ Returns a single value for the ``Property`` whether or not it is multivalued.
+        """
+
         try:
-            return next(self.get())
+            r = self.get()
+            return next(iter(r))
         except StopIteration:
             return None
 
     def hasValue(self):
+        """ Returns true if the Property has any values set on it.
+
+        This may be defined differently for each property
+        """
         return True
 
     def __call__(self,*args,**kwargs):
+        """ If arguments are passed to the ``Property``, its ``set`` method
+        is called. Otherwise, the ``get`` method is called. If the ``multiple``
+        member for the ``Property`` is set to ``True``, then a Python set containing
+        the associated values is returned. Otherwise, a single bare value is returned.
+        """
+
         if len(args) > 0 or len(kwargs) > 0:
             self.set(*args,**kwargs)
             return self
         else:
-            return self.get(*args,**kwargs)
+            r = self.get(*args,**kwargs)
+            if self.multiple:
+                return set(r)
+            else:
+                try:
+                    return next(iter(r))
+                except StopIteration:
+                    return None
+
     # Get the property (a relationship) itself
 
 class SimpleProperty(Property):
-    """ A property that has just one link to a literal or DataObject """
+    """ A property that has one or more links to a literals or DataObjects """
 
     def __init__(self,**kwargs):
         if not hasattr(self,'linkName'):
@@ -466,9 +505,14 @@ class SimpleProperty(Property):
             self.link = self.owner_type.rdf_namespace[self.linkName]
 
     def hasValue(self):
+        """ Returns true if the ``Property`` has had ``load`` called previously and some value was available or if ``set`` has been called previously """
         return len(self.v) > 0
 
     def get(self):
+        """ If the ``Property`` has had ``load`` or ``set`` called previously, returns
+        the resulting values. Otherwise, queries the configured rdf graph for values
+        which are set for the ``Property``'s owner.
+        """
         if len(self.v) > 0:
             for x in self.v:
                 if isinstance(x, R.Literal):
@@ -532,10 +576,11 @@ class SimpleProperty(Property):
             gv = self._graph_variable(self.linkName)
             yield (owner_id, self.link, ident)
             yield (ident, self.value_property, gv)
-    def load(self):
-        """ Load in data from the database. Derived classes should override this for their own data structures.
 
-        :param self: An object which limits the set of objects which can be returned. Should have the configuration necessary to do the query
+    def load(self):
+        """ Loads in values to this ``Property`` which have been set for the associated owner,
+        or if the owner refers to an unspecified member of its class, loads values which could
+        be set based on the constraints on the owner.
 
         """
         # This load is way simpler since we just need the values for this property

--- a/PyOpenWorm/evidence.py
+++ b/PyOpenWorm/evidence.py
@@ -39,6 +39,7 @@ def _json_request(url):
 
 class AssertsAllAbout(Property):
     # TODO: Needs tests!
+    multiple=True
     def __init__(self, **kwargs):
         Property.__init__(self, 'asserts_all_about', **kwargs)
 
@@ -124,16 +125,21 @@ class Evidence(DataObject):
         #        ; field3 value3 .
         DataObject.__init__(self, conf=conf)
         self._fields = dict()
-        Evidence.ObjectProperty('asserts', owner=self)
+        Evidence.ObjectProperty('asserts', multiple=True, owner=self)
         AssertsAllAbout(owner=self)
-        fields = ('author',
-                'year',
+
+        multivalued_fields = ('author', 'uri')
+
+        for x in multivalued_fields:
+            Evidence.DatatypeProperty(x, multiple=True, owner=self)
+
+        other_fields = ('year',
                 'title',
                 'doi',
                 'wbid',
-                'pmid',
-                'uri')
-        for x in fields:
+                'pmid')
+        fields = multivalued_fields + other_fields
+        for x in other_fields:
             Evidence.DatatypeProperty(x, owner=self)
 
         #XXX: I really don't like putting these in two places
@@ -152,6 +158,7 @@ class Evidence(DataObject):
                 self.doi(source[k])
             if k in ('bibtex',):
                 self._fields['bibtex'] = source[k]
+
             if k in fields:
                 getattr(self,k)(source[k])
 

--- a/PyOpenWorm/muscle.py
+++ b/PyOpenWorm/muscle.py
@@ -12,5 +12,5 @@ class Muscle(Cell):
 
     def __init__(self, name=False, **kwargs):
         Cell.__init__(self, name=name, **kwargs)
-        self.innervatedBy = Muscle.ObjectProperty("neurons",owner=self,value_type=P.Neuron)
-        Muscle.DatatypeProperty("receptors",owner=self)
+        self.innervatedBy = Muscle.ObjectProperty("neurons",owner=self,value_type=P.Neuron, multiple=True)
+        Muscle.DatatypeProperty("receptors",owner=self,multiple=True)

--- a/PyOpenWorm/network.py
+++ b/PyOpenWorm/network.py
@@ -15,13 +15,12 @@ class Network(DataObject):
     """
     def __init__(self, **kwargs):
         DataObject.__init__(self,**kwargs)
-        self.synapses = Network.ObjectProperty('synapse',owner=self,value_type=P.Connection)
-        Network.ObjectProperty('neuron',owner=self,value_type=P.Neuron)
+        self.synapses = Network.ObjectProperty('synapse',owner=self,value_type=P.Connection, multiple=True)
+        Network.ObjectProperty('neuron',owner=self,value_type=P.Neuron, multiple=True)
 
     def neurons(self):
         for x in self.neuron():
-            for n in x.name():
-                yield n
+            yield x.name()
 
     def aneuron(self, name):
         """

--- a/PyOpenWorm/neuron.py
+++ b/PyOpenWorm/neuron.py
@@ -7,6 +7,7 @@ from PyOpenWorm import Cell
 # XXX: Should we specify somewhere whether we have NetworkX or something else?
 
 class Neighbor(P.Property):
+    multiple=True
     def __init__(self,**kwargs):
         P.Property.__init__(self,'neighbor',**kwargs)
         self._conns = []
@@ -24,13 +25,11 @@ class Neighbor(P.Property):
         """
         if len(self._conns) > 0:
             for c in self._conns:
-                for x in c.post_cell():
-                    yield x
+                yield c.post_cell()
         else:
             c = P.Connection(pre_cell=self.owner,**kwargs)
             for r in c.load():
-                for x in r.post_cell():
-                    yield x
+                yield r.post_cell()
 
     def set(self, other, **kwargs):
         c = P.Connection(pre_cell=self.owner,post_cell=other,**kwargs)
@@ -43,6 +42,7 @@ class Neighbor(P.Property):
                 yield x
 
 class Connection(P.Property):
+    multiple=True
     def __init__(self,**kwargs):
         P.Property.__init__(self,'connection',**kwargs)
         self._conns = []
@@ -168,8 +168,8 @@ class Neuron(Cell):
         Connection(owner=self)
 
         Neuron.DatatypeProperty("type",self)
-        Neuron.DatatypeProperty("receptor",self)
-        Neuron.DatatypeProperty("innexin",self)
+        Neuron.DatatypeProperty("receptor", self, multiple=True)
+        Neuron.DatatypeProperty("innexin", self, multiple=True)
         ### Aliases ###
         self.get_neighbors = self.neighbor
         self.receptors = self.receptor

--- a/PyOpenWorm/worm.py
+++ b/PyOpenWorm/worm.py
@@ -24,7 +24,7 @@ class Worm(DataObject):
         DataObject.__init__(self,**kwargs)
         self.name = Worm.DatatypeProperty("scientific_name", owner=self)
         Worm.ObjectProperty("neuron_network", owner=self, value_type=Network)
-        Worm.ObjectProperty("muscle", owner=self, value_type=Muscle)
+        Worm.ObjectProperty("muscle", owner=self, value_type=Muscle, multiple=True)
         Worm.ObjectProperty("cell", owner=self, value_type=Cell)
 
         if scientific_name:
@@ -39,8 +39,7 @@ class Worm(DataObject):
         :returns: An object to work with the network of the worm
         :rtype: PyOpenWorm.Network
         """
-        for x in self.neuron_network():
-            return x
+        return self.neuron_network()
 
     def muscles(self):
         """
@@ -49,7 +48,7 @@ class Worm(DataObject):
         :returns: A list of all muscle names
         :rtype: list
          """
-        for x in self.muscle():
+        for x in self.muscle.get():
             yield x
 
     def get_semantic_net(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -198,7 +198,7 @@ class CellTest(_DataTest):
         c = Cell(name="ADAL",conf=self.config)
         c.lineageName("AB plapaaaapp")
         c.save()
-        self.assertEqual(["AB plapaaaapp"], list(Cell(name="ADAL").lineageName()))
+        self.assertEqual("AB plapaaaapp", Cell(name="ADAL").lineageName())
 
     def test_same_name_same_id(self):
         """
@@ -248,7 +248,7 @@ class CellTest(_DataTest):
             ln = base + l
             Cell(name=x,lineageName=ln).save()
 
-        names = set(str(next(x.name())) for x in p.parentOf())
+        names = set(str(x.name()) for x in p.parentOf())
         self.assertEqual(set(c), names)
 
     def test_daughterOf(self):
@@ -262,7 +262,7 @@ class CellTest(_DataTest):
         c = Cell(name="carrots")
         c.lineageName("ab.tahsuetoahusenoatu")
         c.save()
-        parent_p = next(c.daughterOf().name())
+        parent_p = c.daughterOf().name()
         self.assertEqual("peas", parent_p)
 
     @unittest.skip('Long runner')
@@ -454,18 +454,18 @@ class NeuronTest(_DataTest):
         n = self.neur('AVAL')
         n.type('interneuron')
         n.save()
-        self.assertIn('interneuron', list(self.neur('AVAL').type()))
+        self.assertEqual('interneuron', self.neur('AVAL').type())
 
     def test_name(self):
         """ Test that the name property is set when the neuron is initialized with it """
-        self.assertEqual(next(self.neur('AVAL').name()), 'AVAL')
-        self.assertEqual(next(self.neur('AVAR').name()), 'AVAR')
+        self.assertEqual('AVAL', self.neur('AVAL').name())
+        self.assertEqual('AVAR', self.neur('AVAR').name())
 
     def test_neighbor(self):
         n = self.neur('AVAL')
         n.neighbor(self.neur('PVCL'))
         neighbors = list(n.neighbor())
-        self.assertIn(self.neur('PVCL'),neighbors)
+        self.assertIn(self.neur('PVCL'), neighbors)
         n.save()
         self.assertIn(self.neur('PVCL'), list(self.neur('AVAL').neighbor()))
 
@@ -473,14 +473,18 @@ class NeuronTest(_DataTest):
         c = Neuron(lineageName="AB plapaaaap",name="ADAL")
         c.save()
         c = Neuron(lineageName="AB plapaaaap")
-        self.assertEqual(next(c.name()), 'ADAL')
+        self.assertEqual(c.name(), 'ADAL')
 
     def test_GJ_degree(self):
         """ Get the number of gap junctions from a networkx representation """
+        # XXX: This test depends on a remote-hosted CSV file. Change it to depend
+        # on the configured RDF graph, seeded by this test
         self.assertEqual(self.neur('AVAL').GJ_degree(),60)
 
     def test_Syn_degree(self):
         """ Get the number of chemical synapses from a networkx representation """
+        # XXX: This test depends on a remote-hosted CSV file. Change it to depend
+        # on the configured RDF graph, seeded by this test
         self.assertEqual(self.neur('AVAL').Syn_degree(),74)
 
 class NetworkTest(_DataTest):
@@ -599,7 +603,7 @@ class EvidenceTest(_DataTest):
         e0 = Evidence()
         e0.asserts(r)
         s = list(e0.load())
-        author = next(s[0].author())
+        author = s[0].author.one()
         self.assertIn('tom@cn.com', author)
 
     def test_asserts_query_multiple(self):
@@ -616,12 +620,11 @@ class EvidenceTest(_DataTest):
         e0 = Evidence()
         e0.asserts(r)
         for x in e0.load():
-            a = list(x.author())
-            y = list(x.year())
+            a = x.author.one()
+            y = x.year()
             # Testing that either a has a result tom@cn.com and y has nothing or
             # y has a result 1999 and a has nothing
-            self.assertTrue((len(a) > 0 and str(a[0]) == 'tom@cn.com' and len(y) == 0) \
-                    or len(a) == 0 and int(y[0]) == 1999)
+            self.assertTrue((a == 'tom@cn.com' and y is None) or (a is None and int(y) == 1999))
 
     def test_asserts_query_multiple_author_matches(self):
         """ Show that setting the evidence with distinct objects yields distinct results even if there are matching values """
@@ -650,15 +653,28 @@ class RDFLibTest(unittest.TestCase):
         except:
             self.fail("Doesn't actually fail...which is weird")
     def test_uriref_not_id(self):
+        """ Test that rdflib throws up a warning when we do something bad """
         #XXX: capture the logged warning
-        # import cStringIO
-        # out = cStringIO.StringIO()
-        rdflib.URIRef("some random string")
+        import cStringIO
+        import logging
+
+        out = cStringIO.StringIO()
+        logger = logging.getLogger()
+        stream_handler = logging.StreamHandler(out)
+        logger.addHandler(stream_handler)
+        try:
+            rdflib.URIRef("some random string")
+        finally:
+            logger.removeHandler(stream_handler)
+        v = out.getvalue()
+        out.close()
+        self.assertRegexpMatches(str(v), r".*some random string.*")
 
     def test_BNode_equality1(self):
         a = rdflib.BNode("some random string")
         b = rdflib.BNode("some random string")
         self.assertEqual(a, b)
+
     def test_BNode_equality2(self):
         a = rdflib.BNode()
         b = rdflib.BNode()
@@ -778,11 +794,11 @@ class ConnectionTest(_DataTest):
     def test_init(self):
         """Initialization with positional parameters"""
         c = Connection('AVAL','ADAR',3,'send','Serotonin')
-        self.assertIsInstance(next(c.pre_cell()), Neuron)
-        self.assertIsInstance(next(c.post_cell()), Neuron)
-        self.assertEqual(next(c.number()), 3)
-        self.assertEqual(next(c.syntype()), 'send')
-        self.assertEqual(next(c.synclass()), 'Serotonin')
+        self.assertIsInstance(c.pre_cell(), Neuron)
+        self.assertIsInstance(c.post_cell(), Neuron)
+        self.assertEqual(c.number(), 3)
+        self.assertEqual(c.syntype(), 'send')
+        self.assertEqual(c.synclass(), 'Serotonin')
 
     def test_init_number_is_a_number(self):
         with self.assertRaises(Exception):


### PR DESCRIPTION
For issue #52

Generators are still returned from `load`, `SimpleProperty.get`
