### PR TITLE
Corrected the format of source code documentation

### DIFF
--- a/PyOpenWorm/__init__.py
+++ b/PyOpenWorm/__init__.py
@@ -76,7 +76,9 @@ from .connection import Connection
 __import__('__main__').connected = False
 
 def config(key=None):
-    """ Gets the main configuration for the whole PyOpenWorm library.
+    """
+    Gets the main configuration for the whole PyOpenWorm library.
+
     :return: the instance of the Configure class currently operating.
     """
     if key is None:
@@ -121,6 +123,7 @@ def connect(configFile='PyOpenWorm/default.conf',
             dataFormat='n3'):
     """
      Load desired configuration and open the database
+
     :param configFile: (Optional) The configuration file for PyOpenWorm
     :param conf: (Optional) If true, initializes a data object with the PyOpenWorm configuration
     :param do_logging: (Optional) If true, turn on debug level logging

--- a/PyOpenWorm/__init__.py
+++ b/PyOpenWorm/__init__.py
@@ -103,7 +103,9 @@ def disconnect(c=False):
 
 
 def loadData(data='OpenWormData/WormData.n3', dataFormat='n3'):
-    """ Load data into the underlying database of this library.
+    """ 
+    Load data into the underlying database of this library.
+
     :param data: (Optional) Specify the file to load into the library
     :param dataFormat: (Optional) Specify the file format to load into the library.  Currently n3 is supported
     :return:

--- a/PyOpenWorm/configure.py
+++ b/PyOpenWorm/configure.py
@@ -81,7 +81,9 @@ class Configure(object):
 
     @classmethod
     def open(cls,file_name):
-        """ Open a configuration file and read it to build the internal state.
+        """ 
+        Open a configuration file and read it to build the internal state.
+
         :param file_name: configuration file encoded as JSON
         :return: a Configure object with the configuration taken from the JSON file
         """
@@ -103,7 +105,9 @@ class Configure(object):
         return c
 
     def copy(self,other):
-        """ Copy this configuration into a different object.
+        """ 
+        Copy this configuration into a different object.
+
         :param other: A different configuration object to copy the configuration from this object into
         :return:
         """
@@ -115,7 +119,9 @@ class Configure(object):
         return self
 
     def get(self, pname, default=False):
-        """ Get some parameter value out by asking for a key
+        """
+        Get some parameter value out by asking for a key
+
         :param pname: they key of the value you want to return.
         :param default: True if you want the default value, False if you don't (default)
         :return: The value corresponding to the key in pname
@@ -135,14 +141,18 @@ class Configureable(object):
         pass
 
     def __getitem__(self,k):
-        """ Get a configuration value out by providing a key k
+        """
+        Get a configuration value out by providing a key k
+
         :param k: the key for the value you wish to retrieve
         :return: the value you want to get back
         """
         return self.conf.get(k)
 
     def __setitem__(self,k,v):
-        """ Set a key - value pair on this object
+        """
+        Set a key - value pair on this object
+
         :param k: The key for the value to set
         :param v: The value to set
         :return: no return
@@ -150,7 +160,9 @@ class Configureable(object):
         self.conf[k] = v
 
     def get(self, pname, default=False):
-        """ The getter for the configuration
+        """
+        The getter for the configuration
+
         :param pname: The key to retreive the value of interest
         :param default: True if you want the default value, False if you don't (default)
         :return: Returns the configuration value corresponding to the key pname.

--- a/PyOpenWorm/data.py
+++ b/PyOpenWorm/data.py
@@ -169,6 +169,7 @@ class DataUser(Configureable):
     def add_reference(self, g, reference_iri):
         """
         Add a citation to a set of statements in the database
+
         :param triples: A set of triples to annotate
         """
         new_statements = Graph()
@@ -185,6 +186,7 @@ class DataUser(Configureable):
     def retract_statements(self, graph):
         """
         Remove a set of statements from the database.
+
         :param graph: An iterable of triples
         """
         self._remove_from_store_by_query(graph)
@@ -198,6 +200,7 @@ class DataUser(Configureable):
         """
         Add a set of statements to the database.
         Annotates the addition with uploader name, etc
+
         :param graph: An iterable of triples
         """
         self._add_to_store(graph)

--- a/PyOpenWorm/dataObject.py
+++ b/PyOpenWorm/dataObject.py
@@ -391,7 +391,8 @@ class DataObject(DataUser):
         cls.rdf_namespace = R.Namespace(cls.rdf_type + "/")
 
     def load0(self):
-        """ Load in data from the database. Derived classes should override this for their own data structures.
+        """
+        Load in data from the database. Derived classes should override this for their own data structures.
 
         ``load()`` returns an iterable object which yields DataObjects which have the same class as the object and have, for the Properties set, the same values
 
@@ -412,10 +413,12 @@ class DataObject(DataUser):
                 yield new_object
 
     def load(self):
-        """ Load in data from the database. Derived classes should override this for their own data structures.
+        """
+        Load in data from the database. Derived classes should override this for their own data structures.
 
         ``load()`` returns an iterable object which yields DataObjects which have the same class as the object and have,
         for the Properties set, the same values
+
         :param self: An object which limits the set of objects which can be returned. Should have the configuration
                      necessary to do the query
         """
@@ -608,6 +611,7 @@ class SimpleProperty(Property):
     def hasValue(self):
         """ Returns true if the ``Property`` has had ``load`` called previously and some value was available or if
         ``set`` has been called previously
+
         :return: True if this data object has a value, False if not.
         """
         return len(self.v) > 0


### PR DESCRIPTION
There was a bug in the doc strings; if there was not a new line before the `:param` or `:return` comments, Sphinx wouldn't parse it properly in the autodoc generation. I've fixed that now. 

This PR fixes issue #86 . 