### PR TITLE
Cleanup restructure tests alpha0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ Basic Usage
 -----------
 
 To get started, you'll probably want to load in the database. If you cloned the repository from Github, then the database will be in the OpenWormData subdirectory. You can read it in
-by doing 
+by doing
 
 ```python
-  >>> import PyOpenWorm as P
-  >>> P.connect()
+>>> import PyOpenWorm as P
+>>> P.connect()
 
-  >>> P.loadData()
-  [PyOpenWorm] Loading data into the graph; this may take several minutes!!
+>>> P.loadData()
 
+[PyOpenWorm] Loading data into the graph; this may take several minutes!!
 
 ```
 
@@ -35,18 +35,18 @@ Then you can try out a few things:
 
 ```python
 
-  # Grabs the representation of the neuronal network
-  >>> net = P.Worm().get_neuron_network()
-  
-  # Grab a specific neuron
-  >>> aval = net.aneuron('AVAL')
-  
-  >>> aval.type()
-  set(['interneuron'])
+# Grabs the representation of the neuronal network
+>>> net = P.Worm().get_neuron_network()
 
-  #show how many connections go out of AVAL
-  >>> aval.connection.count('pre')
-  77
+# Grab a specific neuron
+>>> aval = net.aneuron('AVAL')
+
+>>> aval.type()
+set(['interneuron'])
+
+#show how many connections go out of AVAL
+>>> aval.connection.count('pre')
+77
 
 ```
 
@@ -57,77 +57,78 @@ There are many different useful ways to compute with data related to the worm.
 Different data structures have different strengths and answer different questions.
 For example, a NetworkX representation of the connectome as a complex graph enables
 questions to be asked about first and second nearest neighbors of a given neuron.
-In contrast, an RDF semantic graph representation is useful for reading and 
-writing annotations about multiple aspects of a neuron, such as what papers 
+In contrast, an RDF semantic graph representation is useful for reading and
+writing annotations about multiple aspects of a neuron, such as what papers
 have been written about it, multiple different properties it may have such as
 ion channels and neurotransmitter receptors.  A NeuroML representation is useful
 for answering questions about model morphology and simulation parameters.  Lastly,
-a Blender representation is a full 3D shape definition that can be used for 
+a Blender representation is a full 3D shape definition that can be used for
 calculations in 3D space.  Further representations regarding activity patterns
 such as Neo or simulated activity can be considered as well.
 
 Using these different representations separately leads to ad hoc scripting for
-for each representation.  This presents a challenge for data integration and 
+for each representation.  This presents a challenge for data integration and
 consolidation of information in 'master' authoritative representations.  By
 creating a unified data access layer, different representations
 can become encapsulated into an abstract view.  This allows the user to work with
-objects related to the biological reality of the worm.  This has the advantage that 
+objects related to the biological reality of the worm.  This has the advantage that
 the user can forget about which representation is being used under the hood.  
 
 The worm itself has a unified sense of neurons, networks, muscles,
 ion channels, etc and so should our code.
-  
+
 More examples
 -------------
-  
+
 Returns information about individual neurons::
 
 ```python
-  >>> aval.name()
-  'AVAL'
+>>> aval.name()
+'AVAL'
 
-  #list all known receptors
-  >>> aval.receptors()
-  set(['GLR-1', 'NMR-1', 'GLR-4', 'GLR-2', 'GGR-3', 'UNC-8', 'GLR-5', 'NMR-2'])
+#list all known receptors
+>>> aval.receptors()
+set(['GLR-1', 'NMR-1', 'GLR-4', 'GLR-2', 'GGR-3', 'UNC-8', 'GLR-5', 'NMR-2'])
 
-  #show how many chemical synapses go in and out of AVAL
-  >>> aval.Syn_degree()
-  74
+#show how many chemical synapses go in and out of AVAL
+>>> aval.Syn_degree()
+74
 
 ```
 
 Returns the list of all neurons::
 
 ```python
-  #NOTE: This is a VERY slow operation right now
-  >>> len(set(net.neurons()))
-  302
-  >>> set(net.neurons())
-  set(['VB4', 'PDEL', 'HSNL', 'SIBDR', ... 'RIAL', 'MCR', 'LUAL'])
+#NOTE: This is a VERY slow operation right now
+>>> len(set(net.neurons()))
+302
+>>> set(net.neurons())
+set(['VB4', 'PDEL', 'HSNL', 'SIBDR', ... 'RIAL', 'MCR', 'LUAL'])
 
 ```
 
 Returns a set of all muscles::
 
 ```python
-  >>> P.Worm().muscles()
-  set([MANAL, MDL23, MVR02, ... MVL09, MVR21, MDR03])
+>>> P.Worm().muscles()
+set([MANAL, MDL23, MVR02, ... MVL09, MVR21, MDR03])
 
 ```
 
 Add some evidence::
 ```python
-  >>> e = P.Evidence(author='Sulston et al.', date='1983')
-  >>> e.asserts(P.Neuron(name="AVDL").lineageName("AB alaaapalr"))
-  asserts=`lineageName=`AB alaaapalr''
-  >>> e.save()
+>>> e = P.Evidence(author='Sulston et al.', date='1983')
+>>> e.asserts(P.Neuron(name="AVDL").lineageName("AB alaaapalr"))
+asserts=`lineageName=`AB alaaapalr''
+>>> e.save()
+
 ```
 
 See what some evidence stated::
 ```python
-  >>> e0 = P.Evidence(author='Sulston et al.', date='1983')
-  >>> list(e0.asserts())
-  [Neuron(name=AVDL,lineageName=AB alaaapalr)]
+>>> e0 = P.Evidence(author='Sulston et al.', date='1983')
+>>> list(e0.asserts())
+[Neuron(name=AVDL,lineageName=AB alaaapalr)]
 
 ```
 
@@ -135,44 +136,45 @@ For most types (i.e., subclasses of `P.DataObject`) that do not have required
 initialization arguments, you can load all members of that type by making an
 object of that type and calling `load()`::
 ```python
-  >>> list(P.Neuron().load())
-  [AS6,SIBVL,AS5,AVKL,VD10,VA5,AVG,AUAR,AWAR,PLML,...]
+>>> list(P.Neuron().load())
+[AS6,SIBVL,AS5,AVKL,VD10,VA5,AVG,AUAR,AWAR,PLML,...]
 
 ```
 
 See what neurons express some neuropeptide::
 ```python
-  >>> n = P.Neuron()
-  >>> n.neuropeptide("TH")
-  neuropeptide=`TH'
+>>> n = P.Neuron()
+>>> n.neuropeptide("TH")
+neuropeptide=`TH'
 
-  >>> s = set(x.name() for x in n.load()) 
-  >>> s == set(['CEPDR', 'PDER', 'CEPDL', 'PDEL', 'CEPVR', 'CEPVL'])
-  True
+>>> s = set(x.name() for x in n.load())
+>>> s == set(['CEPDR', 'PDER', 'CEPDL', 'PDEL', 'CEPVR', 'CEPVL'])
+True
 
 ```
 
 See what neurons innervate a muscle (you may get different muscles stored as 'a_muscle' that come out of the un-ordered set)::
 ```python
-   >>> muscles = P.Worm().muscles()
-   >>> a_muscle = muscles.pop()
-   >>> a_muscle
-   MRV17
-   >>> a_muscle.innervatedBy()
-   set([VB8, VD10, VB9, VD9, VA10])
+ >>> muscles = P.Worm().muscles()
+ >>> a_muscle = muscles.pop()
+ >>> a_muscle
+ MRV17
+ >>> a_muscle.innervatedBy()
+ set([VB8, VD10, VB9, VD9, VA10])
 
 ```
 Get direct access to the RDFLib graph::
 ```python
- >>> P.config('rdf.graph').query("SELECT ?y WHERE { ?x rdf:type ?y }")
- <rdflib.plugins.sparql.processor.SPARQLResult object at 0x10fb77f90>
+ >>> P.config('rdf.graph').query("SELECT ?y WHERE { ?x rdf:type ?y }") # doctest:+ELLIPSIS
+ <rdflib.plugins.sparql.processor.SPARQLResult object at ...>
+ 
 ```
 
 Returns the C. elegans connectome represented as a [NetworkX](http://networkx.github.io/documentation/latest/) graph::
 
 ```python
-  >>> net.as_networkx()
-  <networkx.classes.digraph.DiGraph object at 0x10f28bc10>
+>>> net.as_networkx() # doctest:+ELLIPSIS
+<networkx.classes.digraph.DiGraph object at ...>
 
 ```
 
@@ -182,18 +184,17 @@ More examples can be found [here](http://pyopenworm.readthedocs.org/en/alpha0.5/
 Ease of use
 -----------
 
-This library should be easy to use and easy to install, to make it most accessible.  Python beginners should be able to get information out about c. elegans from this library.  Sytactical constructs in this library should be intuitive and easy to understand what they will return within the knowledge domain of c. elegans, 
+This library should be easy to use and easy to install, to make it most accessible.  Python beginners should be able to get information out about c. elegans from this library.  Sytactical constructs in this library should be intuitive and easy to understand what they will return within the knowledge domain of c. elegans,
 rather than in the programming domain of its underlying technologies.  Values that are returned should be easily interpretable and easy to read.
 Wherever possible, pure-python libraries or those with few compilation requirements, rather than those that create extra dependencies on external native libraries are used.
 
 Versioning data as code
 -----------------------
-As the underlying data sets that define the c. elegans anatomy change over time, these 
-changes can often break a library that attempts to reliably expose those data.  This is 
+As the underlying data sets that define the c. elegans anatomy change over time, these
+changes can often break a library that attempts to reliably expose those data.  This is
 because data changes can cause queries to return different answers than before, causing
 unit tests that rely on those answers to no longer correctly return.  As such, to create
-a stable foundational library for others to reuse, the version of the PyOpenWorm library 
+a stable foundational library for others to reuse, the version of the PyOpenWorm library
 guarantees the user a specific version of the data behind that library.  As data
 are improved, the maintainers of the library can perform appropriate regression tests
 prior to each new release to guarantee stability.
-

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Get direct access to the RDFLib graph::
 ```python
  >>> P.config('rdf.graph').query("SELECT ?y WHERE { ?x rdf:type ?y }") # doctest:+ELLIPSIS
  <rdflib.plugins.sparql.processor.SPARQLResult object at ...>
- 
+
 ```
 
 Returns the C. elegans connectome represented as a [NetworkX](http://networkx.github.io/documentation/latest/) graph::
@@ -175,6 +175,12 @@ Returns the C. elegans connectome represented as a [NetworkX](http://networkx.gi
 ```python
 >>> net.as_networkx() # doctest:+ELLIPSIS
 <networkx.classes.digraph.DiGraph object at ...>
+
+```
+
+Finally, when you're done accessing the database, be sure to disconnect from it::
+```python
+>>> P.disconnect()
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See what neurons innervate a muscle (you may get different muscles stored as 'a_
 Get direct access to the RDFLib graph::
 ```python
  >>> P.config('rdf.graph').query("SELECT ?y WHERE { ?x rdf:type ?y }")
-
+ <rdflib.plugins.sparql.processor.SPARQLResult object at 0x10fb77f90>
 ```
 
 Returns the C. elegans connectome represented as a [NetworkX](http://networkx.github.io/documentation/latest/) graph::

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 xlrd
 libneuroml
-ZODB
+zodb==4.1.0
 Pint
 rdflib>=4.1.2
 BTrees==4.0.8

--- a/tests/ConfigureTest.py
+++ b/tests/ConfigureTest.py
@@ -1,0 +1,76 @@
+import sys
+sys.path.insert(0,".")
+import unittest
+import neuroml
+import neuroml.writers as writers
+import PyOpenWorm
+from PyOpenWorm import *
+import test_data as TD
+import networkx
+import rdflib
+import rdflib as R
+import pint as Q
+import os
+import subprocess as SP
+import subprocess
+import tempfile
+import doctest
+
+from glob import glob
+
+class ConfigureTest(unittest.TestCase):
+    def test_fake_config(self):
+        """ Try to retrieve a config value that hasn't been set """
+        with self.assertRaises(KeyError):
+            c = Configure()
+            c['not_a_valid_config']
+
+    def test_literal(self):
+        """ Assign a literal rather than a ConfigValue"""
+        c = Configure()
+        c['seven'] = "coke"
+        self.assertEqual(c['seven'], "coke")
+
+    def test_ConfigValue(self):
+        """ Assign a ConfigValue"""
+        c = Configure()
+        class pipe(ConfigValue):
+            def get(self):
+                return "sign"
+        c['seven'] = pipe()
+        self.assertEqual("sign",c['seven'])
+
+    def test_getter_no_ConfigValue(self):
+        """ Assign a method with a "get". Should return a the object rather than calling its get method """
+        c = Configure()
+        class pipe:
+            def get(self):
+                return "sign"
+        c['seven'] = pipe()
+        self.assertIsInstance(c['seven'], pipe)
+
+    def test_late_get(self):
+        """ "get" shouldn't be called until the value is *dereferenced* """
+        c = Configure()
+        a = {'t' : False}
+        class pipe(ConfigValue):
+            def get(self):
+                a['t'] = True
+                return "sign"
+        c['seven'] = pipe()
+        self.assertFalse(a['t'])
+        self.assertEqual(c['seven'], "sign")
+        self.assertTrue(a['t'])
+
+    def test_read_from_file(self):
+        """ Read configuration from a JSON file """
+        try:
+            d = Data.open("tests/test.conf")
+            self.assertEqual("test_value", d["test_variable"])
+        except:
+            self.fail("test.conf should exist and be valid JSON")
+
+    def test_read_from_file_fail(self):
+        """ Fail on attempt to read configuration from a non-JSON file """
+        with self.assertRaises(ValueError):
+            Data.open("tests/bad_test.conf")

--- a/tests/ConfigureableTest.py
+++ b/tests/ConfigureableTest.py
@@ -1,0 +1,30 @@
+import sys
+sys.path.insert(0,".")
+import unittest
+import neuroml
+import neuroml.writers as writers
+import PyOpenWorm
+from PyOpenWorm import *
+import test_data as TD
+import networkx
+import rdflib
+import rdflib as R
+import pint as Q
+import os
+import subprocess as SP
+import subprocess
+import tempfile
+import doctest
+
+from glob import glob
+
+class ConfigureableTest(unittest.TestCase):
+    def test_init_empty(self):
+        """Ensure Configureable gets init'd with the defalut if nothing's given"""
+        i = Configureable()
+        self.assertEqual(Configureable.conf,i.conf)
+
+    def test_init_False(self):
+        """Ensure Configureable gets init'd with the defalut if False is given"""
+        i = Configureable(conf=False)
+        self.assertEqual(Configureable.conf, i.conf)

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -1,0 +1,276 @@
+import sys
+sys.path.insert(0,".")
+import unittest
+import neuroml
+import neuroml.writers as writers
+import PyOpenWorm
+from PyOpenWorm import *
+import test_data as TD
+import networkx
+import rdflib
+import rdflib as R
+import pint as Q
+import os
+import subprocess as SP
+import subprocess
+import tempfile
+import doctest
+
+from glob import glob
+
+USE_BINARY_DB = False
+BINARY_DB = "OpenWormData/worm.db"
+TEST_CONFIG = "tests/default_test.conf"
+try:
+    import bsddb
+    has_bsddb = True
+except ImportError:
+    has_bsddb = False
+
+try:
+    import numpy
+    has_numpy = True
+except ImportError:
+    has_numpy = False
+
+namespaces = { "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#" }
+
+def clear_graph(graph):
+    graph.update("CLEAR ALL")
+
+def make_graph(size=100):
+    """ Make an rdflib graph """
+    g = R.Graph()
+    for i in range(size):
+        s = rdflib.URIRef("http://somehost.com/s"+str(i))
+        p = rdflib.URIRef("http://somehost.com/p"+str(i))
+        o = rdflib.URIRef("http://somehost.com/o"+str(i))
+        g.add((s,p,o))
+    return g
+
+def delete_zodb_data_store(path):
+    os.unlink(path)
+    os.unlink(path + '.index')
+    os.unlink(path + '.tmp')
+    os.unlink(path + '.lock')
+
+class DataIntegrityTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import csv
+
+        cls.neurons = [] #array that holds the names of the 302 neurons at class-level scope
+
+        if not USE_BINARY_DB:
+            PyOpenWorm.connect(conf=Data()) # Connect for integrity tests that use PyOpenWorm functions
+            cls.g = PyOpenWorm.config('rdf.graph') # declare class-level scope for the database
+            cls.g.parse("OpenWormData/WormData.n3", format="n3") # load in the database
+        else:
+            conf = Configure(**{ "rdf.source" : "ZODB", "rdf.store_conf" : BINARY_DB })
+            PyOpenWorm.connect(conf=conf)
+            cls.g = PyOpenWorm.config('rdf.graph')
+
+        #grab the list of the names of the 302 neurons
+
+        csvfile = open('OpenWormData/aux_data/neurons.csv', 'r')
+        reader = csv.reader(csvfile, delimiter=';', quotechar='|')
+
+        for row in reader:
+            if len(row[0]) > 0: # Only saves valid neuron names
+                cls.neurons.append(row[0])
+    @classmethod
+    def tearDownClass(cls):
+        PyOpenWorm.disconnect()
+
+    @unittest.expectedFailure
+    def test_correct_neuron_number(self):
+        """
+        This test verifies that the worm model has exactly 302 neurons.
+        """
+        net = PyOpenWorm.Worm().get_neuron_network()
+        self.assertEqual(302, len(set(net.neurons())))
+
+    @unittest.expectedFailure
+    def test_TH_neuropeptide_neuron_list(self):
+        """
+        This test verifies that the set of neurons which contain the
+        neuropeptide TH is correct (the list is given below).
+        """
+        neuronlist = PyOpenWorm.Neuron()
+        neuronlist.neuropeptide("TH")
+        thlist = set(x.name() for x in neuronlist.load())
+        self.assertEqual(set(['CEPDR', 'PDER', 'CEPDL', 'PDEL', 'CEPVR', 'CEPVL']), thlist)
+
+    def testUniqueNeuronNode(self):
+        """
+        There should one and only one unique RDF node for every neuron.  If more than one is present for a given cell name,
+        then our data is inconsistent.  If there is not at least one present, then we are missing neurons.
+        """
+
+        results = {}
+        for n in self.neurons:
+            #Create a SPARQL query per neuron that looks for all RDF nodes that have text matching the name of the neuron
+            qres = self.g.query('SELECT distinct ?n WHERE {?n ?t ?s . ?s ?p \"' + n + '\" } LIMIT 5')
+            results[n] = (len(qres.result), [x[0] for x in qres.result])
+
+        # If there is not only one result back, then there is more than one RDF node.
+        more_than_one = [(x, results[x]) for x in results if results[x][0] > 1]
+        less_than_one = [(x, results[x]) for x in results if results[x][0] < 1]
+        self.assertEqual(0, len(more_than_one), "Some neurons have more than 1 node: " + "\n".join(str(x) for x in more_than_one))
+        self.assertEqual(0, len(less_than_one), "Some neurons have no node: " + "\n".join(str(x) for x in less_than_one))
+
+    def testNeuronsHaveTypes(self):
+        """
+        Every Neuron should have a non-blank type
+        """
+        results = set()
+        for n in self.neurons:
+            qres = self.g.query('SELECT ?v WHERE { ?s <http://openworm.org/entities/SimpleProperty/value> \"' + n + '\". ' #per node ?s that has the name of a neuron associated
+                                + '?k <http://openworm.org/entities/Cell/name> ?s .'
+                                + '?k <http://openworm.org/entities/Neuron/type> ?o .' #look up its listed type ?o
+                                + '?o <http://openworm.org/entities/SimpleProperty/value> ?v } ' #for that type ?o, get its property ?tp and its value ?v
+                                )
+            for x in qres:
+                v = x[0]
+                if isinstance(v,R.Literal):
+                    results.add(n)
+
+        # NOTE: Neurons ALNL, CANL, CANR, ALNR have unknown function and type
+        self.assertEqual(len(results), len(self.neurons) - 4, "Some neurons are missing a type: {}".format(set(self.neurons) - results))
+
+    def test_neuron_GJ_degree(self):
+        """ Get the number of gap junctions from a networkx representation """
+        self.assertEqual(PyOpenWorm.Neuron(name='AVAL').GJ_degree(), 40)
+
+    def test_neuron_Syn_degree(self):
+        """ Get the number of chemical synapses from a networkx representation """
+        # XXX: This result is 1 greater compared to what would be expected from the
+        # connectome.csv file
+        self.assertEqual(PyOpenWorm.Neuron(name='AVAL').Syn_degree(), 91)
+
+    @unittest.skip("have not yet defined asserts")
+    def testWhatNodesGetTypeInfo(self):
+        qres = self.g.query('SELECT ?o ?p ?s WHERE {'
+                                + '?o <http://openworm.org/entities/SimpleProperty/value> "motor". '
+                                  '?o ?p ?s} ' #for that type ?o, get its value ?v
+                                + 'LIMIT 10')
+        for row in qres.result:
+            print row
+
+    @unittest.expectedFailure
+    def test_compare_to_xls(self):
+        """ Compare the PyOpenWorm connections to the data in the spreadsheet """
+        SAMPLE_CELL = 'ADAL'
+        xls_conns = []
+        pow_conns = []
+
+        #QUERY TO GET ALL CONNECTIONS WHERE SAMPLE_CELL IS ON THE PRE SIDE
+        qres = self.g.query("""SELECT ?post_name ?type (STR(?num) AS ?numval) WHERE {
+                               #############################################################
+                               # Find connections that have the ?pre_name as our passed in value
+                               #############################################################
+                               ?pre_namenode <http://openworm.org/entities/SimpleProperty/value> \'"""
+                               + SAMPLE_CELL +
+                               """\'.
+                               ?pre_cell <http://openworm.org/entities/Cell/name> ?pre_namenode.
+                               ?pre <http://openworm.org/entities/SimpleProperty/value> ?pre_cell.
+                               ?conn <http://openworm.org/entities/Connection/pre_cell> ?pre.
+
+                               #############################################################
+                               # Find all the cells that are on the post side of those
+                               #  connections and bind their names to ?post_name
+                               #############################################################
+                               ?conn <http://openworm.org/entities/Connection/post_cell> ?post.
+                               ?post <http://openworm.org/entities/SimpleProperty/value> ?post_cell.
+                               ?post_cell <http://openworm.org/entities/Cell/name> ?post_namenode.
+                               ?post_namenode <http://openworm.org/entities/SimpleProperty/value> ?post_name.
+
+                               ############################################################
+                               # Go find the type of the connection and bind to ?type
+                               #############################################################
+                               ?conn <http://openworm.org/entities/Connection/syntype> ?syntype_node.
+                               ?syntype_node <http://openworm.org/entities/SimpleProperty/value> ?type.
+
+                               ############################################################
+                               # Go find the number of the connection and bind to ?num
+                               ############################################################
+                               ?conn <http://openworm.org/entities/Connection/number> ?number_node.
+                               ?number_node <http://openworm.org/entities/SimpleProperty/value> ?num.
+
+                               ############################################################
+                               # Filter out any ?pre_names or ?post_names that aren't literals
+                               ############################################################
+                               FILTER(isLiteral(?post_name))}""")
+        def ff(x):
+            return str(x.value)
+        for line in qres.result:
+            t = list(map(ff, line))
+            t.insert(0,SAMPLE_CELL) #Insert sample cell name into the result set after the fact
+            pow_conns.append(t)
+
+        #QUERY TO GET ALL CONNECTIONS WHERE SAMPLE_CELL IS ON THE *POST* SIDE
+        qres = self.g.query("""SELECT ?pre_name ?type (STR(?num) AS ?numval) WHERE {
+                               #############################################################
+                               # Find connections that have the ?post_name as our passed in value
+                               #############################################################
+                               ?post_namenode <http://openworm.org/entities/SimpleProperty/value> \'"""
+                               + SAMPLE_CELL +
+                               """\'.
+                               ?post_cell <http://openworm.org/entities/Cell/name> ?post_namenode.
+                               ?post <http://openworm.org/entities/SimpleProperty/value> ?post_cell.
+                               ?conn <http://openworm.org/entities/Connection/post_cell> ?post.
+
+                               #############################################################
+                               # Find all the cells that are on the pre side of those
+                               #  connections and bind their names to ?pre_name
+                               #############################################################
+                               ?conn <http://openworm.org/entities/Connection/pre_cell> ?pre.
+                               ?pre <http://openworm.org/entities/SimpleProperty/value> ?pre_cell.
+                               ?pre_cell <http://openworm.org/entities/Cell/name> ?pre_namenode.
+                               ?pre_namenode <http://openworm.org/entities/SimpleProperty/value> ?pre_name.
+
+                               ############################################################
+                               # Go find the type of the connection and bind to ?type
+                               #############################################################
+                               ?conn <http://openworm.org/entities/Connection/syntype> ?syntype_node.
+                               ?syntype_node <http://openworm.org/entities/SimpleProperty/value> ?type.
+
+                               ############################################################
+                               # Go find the number of the connection and bind to ?num
+                               ############################################################
+                               ?conn <http://openworm.org/entities/Connection/number> ?number_node.
+                               ?number_node <http://openworm.org/entities/SimpleProperty/value> ?num.
+
+                               ############################################################
+                               # Filter out any ?pre_names or ?post_names that aren't literals
+                               ############################################################
+                               FILTER(isLiteral(?pre_name))}""")
+        for line in qres.result:
+            t = list(map(ff, line))
+            t.insert(1,SAMPLE_CELL) #Insert sample cell name into the result set after the fact
+            pow_conns.append(t)
+
+        #Get connections from the sheet
+        import xlrd
+        wb = xlrd.open_workbook('OpenWormData/aux_data/NeuronConnect.xls')
+        sheet = wb.sheets()[0]
+        #Put every ADAL connection (except EMJs and Rs!) in a list as a tuple. This helps us compare them later
+        def floatToStr(x):
+            return str(int(x.value))
+        def sendOrGj(x):
+            if x.value == 'EJ':
+                return 'gapJunction'
+            else:
+                return 'send'
+
+        for row in range(1, sheet.nrows):
+            if SAMPLE_CELL in [sheet.cell(row, 0).value, sheet.cell(row, 1).value] and sheet.cell(row, 2).value in ['S', 'Sp', 'EJ']:
+                string_row = [str(sheet.cell(row, 0).value), str(sheet.cell(row, 1).value), sendOrGj(sheet.cell(row, 2)), floatToStr(sheet.cell(row, 3))]
+                t = list(string_row)
+                xls_conns.append(t)
+
+        #assert that these two sorted lists are the same
+        #using sorted lists because Set() removes multiples
+
+        self.maxDiff = None
+        self.assertEqual(sorted(pow_conns), sorted(xls_conns))

--- a/tests/DataObjectTestToo.py
+++ b/tests/DataObjectTestToo.py
@@ -1,0 +1,27 @@
+import sys
+sys.path.insert(0,".")
+import unittest
+import neuroml
+import neuroml.writers as writers
+import PyOpenWorm
+from PyOpenWorm import *
+import test_data as TD
+import networkx
+import rdflib
+import rdflib as R
+import pint as Q
+import os
+import subprocess as SP
+import subprocess
+import tempfile
+import doctest
+
+from glob import glob
+
+
+class DataObjectTestToo(unittest.TestCase):
+    def test_helpful_message_on_non_connection(self):
+        """ The message should say something about connecting """
+        Configureable.conf = False # Ensure that we are disconnected
+        with self.assertRaisesRegexp(Exception, ".*[cC]onnect.*"):
+            do = DataObject()

--- a/tests/DataTest.py
+++ b/tests/DataTest.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+
+import sys
+sys.path.insert(0,".")
+import unittest
+import neuroml
+import neuroml.writers as writers
+import PyOpenWorm
+from PyOpenWorm import *
+import test_data as TD
+import networkx
+import rdflib
+import rdflib as R
+import pint as Q
+import os
+import subprocess as SP
+import subprocess
+import tempfile
+import doctest
+
+from glob import glob
+
+USE_BINARY_DB = False
+BINARY_DB = "OpenWormData/worm.db"
+TEST_CONFIG = "tests/default_test.conf"
+try:
+    import bsddb
+    has_bsddb = True
+except ImportError:
+    has_bsddb = False
+
+try:
+    import numpy
+    has_numpy = True
+except ImportError:
+    has_numpy = False
+
+namespaces = { "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#" }
+
+def clear_graph(graph):
+    graph.update("CLEAR ALL")
+
+def make_graph(size=100):
+    """ Make an rdflib graph """
+    g = R.Graph()
+    for i in range(size):
+        s = rdflib.URIRef("http://somehost.com/s"+str(i))
+        p = rdflib.URIRef("http://somehost.com/p"+str(i))
+        o = rdflib.URIRef("http://somehost.com/o"+str(i))
+        g.add((s,p,o))
+    return g
+
+def delete_zodb_data_store(path):
+    os.unlink(path)
+    os.unlink(path + '.index')
+    os.unlink(path + '.tmp')
+    os.unlink(path + '.lock')
+
+class DataTest(unittest.TestCase):
+    def test_namespace_manager(self):
+        c = Configure()
+        c['rdf.source'] = 'default'
+        c['rdf.store'] = 'default'
+        Configureable.conf = c
+        d = Data()
+        d.openDatabase()
+
+        self.assertIsInstance(d['rdf.namespace_manager'], R.namespace.NamespaceManager)
+
+    def test_init_no_rdf_store(self):
+        """ Should be able to init without these values """
+        c = Configure()
+        Configureable.conf = c
+        d = Data()
+        try:
+            d.openDatabase()
+        except:
+            self.fail("Bad state")
+
+    def test_ZODB_persistence(self):
+        """ Should be able to init without these values """
+        c = Configure()
+        fname ='ZODB.fs'
+        c['rdf.source'] = 'ZODB'
+        c['rdf.store_conf'] = fname
+        Configureable.conf = c
+        d = Data()
+        try:
+            d.openDatabase()
+            g = make_graph(20)
+            for x in g:
+                d['rdf.graph'].add(x)
+            d.closeDatabase()
+
+            d.openDatabase()
+            self.assertEqual(20, len(list(d['rdf.graph'])))
+            d.closeDatabase()
+        except:
+            traceback.print_exc()
+            self.fail("Bad state")
+        delete_zodb_data_store(fname)
+
+    @unittest.skipIf((has_bsddb==False), "Sleepycat requires working bsddb")
+    def test_Sleepycat_persistence(self):
+        """ Should be able to init without these values """
+        c = Configure()
+        fname='Sleepycat_store'
+        c['rdf.source'] = 'Sleepycat'
+        c['rdf.store_conf'] = fname
+        Configureable.conf = c
+        d = Data()
+        try:
+            d.openDatabase()
+            g = make_graph(20)
+            for x in g:
+                d['rdf.graph'].add(x)
+            d.closeDatabase()
+
+            d.openDatabase()
+            self.assertEqual(20, len(list(d['rdf.graph'])))
+            d.closeDatabase()
+        except:
+            traceback.print_exc()
+            self.fail("Bad state")
+
+        subprocess.call("rm -rf "+fname, shell=True)
+
+    def test_trix_source(self):
+        """ Test that we can load the datbase up from an XML file.
+        """
+        f = tempfile.mkstemp()
+
+        c = Configure()
+        c['rdf.source'] = 'trix'
+        c['rdf.store'] = 'default'
+        c['trix_location'] = f[1]
+
+        with open(f[1],'w') as fo:
+            fo.write(TD.TriX_data)
+
+        connect(conf=c)
+        c = config()
+
+        try:
+            g = c['rdf.graph']
+            b = g.query("ASK { ?S ?P ?O }")
+            for x in b:
+                self.assertTrue(x)
+        except ImportError:
+            pass
+        finally:
+            disconnect()
+        os.unlink(f[1])
+
+    def test_trig_source(self):
+        """ Test that we can load the datbase up from a trig file.
+        """
+        f = tempfile.mkstemp()
+
+        c = Configure()
+        c['rdf.source'] = 'serialization'
+        c['rdf.serialization'] = f[1]
+        c['rdf.serialization_format'] = 'trig'
+        c['rdf.store'] = 'default'
+        with open(f[1],'w') as fo:
+            fo.write(TD.Trig_data)
+
+        connect(conf=c)
+        c = config()
+
+        try:
+            g = c['rdf.graph']
+            b = g.query("ASK { ?S ?P ?O }")
+            for x in b:
+                self.assertTrue(x)
+        except ImportError:
+            pass
+        finally:
+            disconnect()

--- a/tests/ExampleRunnerTest.py
+++ b/tests/ExampleRunnerTest.py
@@ -1,0 +1,67 @@
+import sys
+sys.path.insert(0,".")
+import unittest
+import neuroml
+import neuroml.writers as writers
+import PyOpenWorm
+from PyOpenWorm import *
+import test_data as TD
+import networkx
+import rdflib
+import rdflib as R
+import pint as Q
+import os
+import subprocess as SP
+import subprocess
+import tempfile
+import doctest
+
+from glob import glob
+
+class ExampleRunnerTest(unittest.TestCase):
+    """ Try to run the examples to make sure we didn't break the API for them. """
+
+    #Currently these are all failing because we aren't reproducing the actual data that
+    # a user gets when they grab the code for the first time
+
+    @classmethod
+    def setUpClass(self):
+        PyOpenWorm.connect()
+        PyOpenWorm.loadData(skipIfNewer=False)
+        PyOpenWorm.disconnect()
+        os.chdir('examples')
+
+    @classmethod
+    def tearDownClass(self):
+        os.chdir('..')
+
+    def execfile(self, example_file_name):
+        fname = tempfile.mkstemp()[1]
+        with open(fname, 'w+') as out:
+            stat = SP.call(["python", example_file_name], stdout=out, stderr=out)
+            out.seek(0)
+            self.assertEqual(0, stat, out.read())
+        os.unlink(fname)
+
+    def test_run_NeuronBasicInfo(self):
+        self.execfile("NeuronBasicInfo.py")
+
+    def test_run_NetworkInfo(self):
+        # XXX: No `synclass' is given, so all neurons are called `excitatory'
+        self.execfile("NetworkInfo.py")
+
+    @unittest.expectedFailure
+    def test_run_morpho(self):
+        self.execfile("morpho.py")
+
+    def test_gap_junctions(self):
+        self.execfile("gap_junctions.py")
+
+    def test_add_reference(self):
+        self.execfile("add_reference.py")
+
+    def test_bgp(self):
+        self.execfile("test_bgp.py")
+
+    def test_rmgr(self):
+        self.execfile("rmgr.py")

--- a/tests/PintTest.py
+++ b/tests/PintTest.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+import sys
+sys.path.insert(0,".")
+import unittest
+import neuroml
+import neuroml.writers as writers
+import PyOpenWorm
+from PyOpenWorm import *
+import test_data as TD
+import networkx
+import rdflib
+import rdflib as R
+import pint as Q
+import os
+import subprocess as SP
+import subprocess
+import tempfile
+import doctest
+
+from glob import glob
+
+class PintTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.ur = Q.UnitRegistry()
+        self.Q = self.ur.Quantity
+    def test_atomic_short(self):
+        q = self.Q(23, "mL")
+        self.assertEqual("milliliter", str(q.units))
+        self.assertEqual(23, q.magnitude)
+
+    def test_atomic_long_singular(self):
+        q = self.Q(23, "milliliter")
+        self.assertEqual("milliliter", str(q.units))
+        self.assertEqual(23, q.magnitude)
+
+    def test_atomic_long_plural(self):
+        q = self.Q(23, "milliliters")
+        self.assertEqual("milliliter", str(q.units))
+        self.assertEqual(23, q.magnitude)
+
+    def test_atomic_long_plural_to_string(self):
+        #XXX: Maybe there's a way to have the unit name pluralized...
+        q = self.Q(23, "milliliters")
+        self.assertEqual("23 milliliter", str(q))
+
+    def test_string_init_long_plural_to_string(self):
+        #XXX: Maybe there's a way to have the unit name pluralized...
+        q = self.Q("23 milliliters")
+        self.assertEqual("23 milliliter", str(q))
+
+    def test_string_init_short(self):
+        q = self.Q("23 mL")
+        self.assertEqual("milliliter", str(q.units))
+        self.assertEqual(23, q.magnitude)
+
+    def test_string_init_short_no_space(self):
+        q = self.Q("23mL")
+        self.assertEqual("milliliter", str(q.units))
+        self.assertEqual(23, q.magnitude)
+
+    def test_string_init_long_singular(self):
+        q = self.Q("23 milliliter")
+        self.assertEqual("milliliter", str(q.units))
+        self.assertEqual(23, q.magnitude)
+
+    def test_string_init_long_plural(self):
+        q = self.Q("23 milliliters")
+        self.assertEqual("milliliter", str(q.units))
+        self.assertEqual(23, q.magnitude)
+
+    def test_init_magnitude_with_string(self):
+        """ Pint doesn't care if you don't give it a number """
+        q = self.Q("23", "milliliters")
+        self.assertEqual("milliliter", str(q.units))
+        self.assertEqual("23", q.magnitude)
+
+        q = self.Q("worm", "milliliters")
+        self.assertEqual("worm", q.magnitude)

--- a/tests/QuantityTest.py
+++ b/tests/QuantityTest.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+import sys
+sys.path.insert(0,".")
+import unittest
+import neuroml
+import neuroml.writers as writers
+import PyOpenWorm
+from PyOpenWorm import *
+import test_data as TD
+import networkx
+import rdflib
+import rdflib as R
+import pint as Q
+import os
+import subprocess as SP
+import subprocess
+import tempfile
+import doctest
+
+from glob import glob
+
+class QuantityTest(unittest.TestCase):
+    def test_string_init_short(self):
+        q = Quantity.parse("23 mL")
+        self.assertEqual("milliliter", q.unit)
+        self.assertEqual(23, q.value)
+
+    def test_string_init_volume(self):
+        q = Quantity.parse("23 inches^3")
+        self.assertEqual("inch ** 3", q.unit)
+        self.assertEqual(23, q.value)
+
+    def test_string_init_compound(self):
+        q = Quantity.parse("23 inches/second")
+        self.assertEqual("inch / second", q.unit)
+        self.assertEqual(23, q.value)
+
+    def test_atomic_short(self):
+        q = Quantity(23, "mL")
+        self.assertEqual("milliliter", q.unit)
+        self.assertEqual(23, q.value)
+
+    def test_atomic_long(self):
+        q = Quantity(23, "milliliters")
+        self.assertEqual("milliliter", q.unit)
+        self.assertEqual(23, q.value)

--- a/tests/RDFLibTest.py
+++ b/tests/RDFLibTest.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+import sys
+sys.path.insert(0,".")
+import unittest
+import neuroml
+import neuroml.writers as writers
+import PyOpenWorm
+from PyOpenWorm import *
+import test_data as TD
+import networkx
+import rdflib
+import rdflib as R
+import pint as Q
+import os
+import subprocess as SP
+import subprocess
+import tempfile
+import doctest
+
+from glob import glob
+
+class RDFLibTest(unittest.TestCase):
+    """Test for RDFLib."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ns = {"ns1" : "http://example.org/"}
+    def test_uriref_not_url(self):
+        try:
+            rdflib.URIRef("daniel@example.com")
+        except:
+            self.fail("Doesn't actually fail...which is weird")
+    def test_uriref_not_id(self):
+        """ Test that rdflib throws up a warning when we do something bad """
+        #XXX: capture the logged warning
+        import cStringIO
+        import logging
+
+        out = cStringIO.StringIO()
+        logger = logging.getLogger()
+        stream_handler = logging.StreamHandler(out)
+        logger.addHandler(stream_handler)
+        try:
+            rdflib.URIRef("some random string")
+        finally:
+            logger.removeHandler(stream_handler)
+        v = out.getvalue()
+        out.close()
+        self.assertRegexpMatches(str(v), r".*some random string.*")
+
+    def test_BNode_equality1(self):
+        a = rdflib.BNode("some random string")
+        b = rdflib.BNode("some random string")
+        self.assertEqual(a, b)
+
+    def test_BNode_equality2(self):
+        a = rdflib.BNode()
+        b = rdflib.BNode()
+        self.assertNotEqual(a, b)

--- a/tests/test.py
+++ b/tests/test.py
@@ -581,135 +581,6 @@ class EvidenceTest(_DataTest):
         e0.asserts(r)
         self.assertTrue(len(list(e0.load())) == 2)
 
-class RDFLibTest(unittest.TestCase):
-    """Test for RDFLib."""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.ns = {"ns1" : "http://example.org/"}
-    def test_uriref_not_url(self):
-        try:
-            rdflib.URIRef("daniel@example.com")
-        except:
-            self.fail("Doesn't actually fail...which is weird")
-    def test_uriref_not_id(self):
-        """ Test that rdflib throws up a warning when we do something bad """
-        #XXX: capture the logged warning
-        import cStringIO
-        import logging
-
-        out = cStringIO.StringIO()
-        logger = logging.getLogger()
-        stream_handler = logging.StreamHandler(out)
-        logger.addHandler(stream_handler)
-        try:
-            rdflib.URIRef("some random string")
-        finally:
-            logger.removeHandler(stream_handler)
-        v = out.getvalue()
-        out.close()
-        self.assertRegexpMatches(str(v), r".*some random string.*")
-
-    def test_BNode_equality1(self):
-        a = rdflib.BNode("some random string")
-        b = rdflib.BNode("some random string")
-        self.assertEqual(a, b)
-
-    def test_BNode_equality2(self):
-        a = rdflib.BNode()
-        b = rdflib.BNode()
-        self.assertNotEqual(a, b)
-
-#class TimeTest(unittest.TestCase):
-    #def test_datetime_isoformat_has_timezone(self):
-        #time_stamp = now(utc).isoformat()
-        #self.assertRegexpMatches(time_stamp, r'.*[+-][0-9][0-9]:[0-9][0-9]$')
-
-class PintTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
-        self.ur = Q.UnitRegistry()
-        self.Q = self.ur.Quantity
-    def test_atomic_short(self):
-        q = self.Q(23, "mL")
-        self.assertEqual("milliliter", str(q.units))
-        self.assertEqual(23, q.magnitude)
-
-    def test_atomic_long_singular(self):
-        q = self.Q(23, "milliliter")
-        self.assertEqual("milliliter", str(q.units))
-        self.assertEqual(23, q.magnitude)
-
-    def test_atomic_long_plural(self):
-        q = self.Q(23, "milliliters")
-        self.assertEqual("milliliter", str(q.units))
-        self.assertEqual(23, q.magnitude)
-
-    def test_atomic_long_plural_to_string(self):
-        #XXX: Maybe there's a way to have the unit name pluralized...
-        q = self.Q(23, "milliliters")
-        self.assertEqual("23 milliliter", str(q))
-
-    def test_string_init_long_plural_to_string(self):
-        #XXX: Maybe there's a way to have the unit name pluralized...
-        q = self.Q("23 milliliters")
-        self.assertEqual("23 milliliter", str(q))
-
-    def test_string_init_short(self):
-        q = self.Q("23 mL")
-        self.assertEqual("milliliter", str(q.units))
-        self.assertEqual(23, q.magnitude)
-
-    def test_string_init_short_no_space(self):
-        q = self.Q("23mL")
-        self.assertEqual("milliliter", str(q.units))
-        self.assertEqual(23, q.magnitude)
-
-    def test_string_init_long_singular(self):
-        q = self.Q("23 milliliter")
-        self.assertEqual("milliliter", str(q.units))
-        self.assertEqual(23, q.magnitude)
-
-    def test_string_init_long_plural(self):
-        q = self.Q("23 milliliters")
-        self.assertEqual("milliliter", str(q.units))
-        self.assertEqual(23, q.magnitude)
-
-    def test_init_magnitude_with_string(self):
-        """ Pint doesn't care if you don't give it a number """
-        q = self.Q("23", "milliliters")
-        self.assertEqual("milliliter", str(q.units))
-        self.assertEqual("23", q.magnitude)
-
-        q = self.Q("worm", "milliliters")
-        self.assertEqual("worm", q.magnitude)
-
-class QuantityTest(unittest.TestCase):
-    def test_string_init_short(self):
-        q = Quantity.parse("23 mL")
-        self.assertEqual("milliliter", q.unit)
-        self.assertEqual(23, q.value)
-
-    def test_string_init_volume(self):
-        q = Quantity.parse("23 inches^3")
-        self.assertEqual("inch ** 3", q.unit)
-        self.assertEqual(23, q.value)
-
-    def test_string_init_compound(self):
-        q = Quantity.parse("23 inches/second")
-        self.assertEqual("inch / second", q.unit)
-        self.assertEqual(23, q.value)
-
-    def test_atomic_short(self):
-        q = Quantity(23, "mL")
-        self.assertEqual("milliliter", q.unit)
-        self.assertEqual(23, q.value)
-
-    def test_atomic_long(self):
-        q = Quantity(23, "milliliters")
-        self.assertEqual("milliliter", q.unit)
-        self.assertEqual(23, q.value)
-
 class ConnectionTest(_DataTest):
     def setUp(self):
         _DataTest.setUp(self)
@@ -796,128 +667,6 @@ class MuscleTest(_DataTest):
 
         m = Muscle(name='MDL08')
         self.assertIn(Neuron('tnnetenba'), list(m.neurons()))
-
-class DataTest(unittest.TestCase):
-    def test_namespace_manager(self):
-        c = Configure()
-        c['rdf.source'] = 'default'
-        c['rdf.store'] = 'default'
-        Configureable.conf = c
-        d = Data()
-        d.openDatabase()
-
-        self.assertIsInstance(d['rdf.namespace_manager'], R.namespace.NamespaceManager)
-
-    def test_init_no_rdf_store(self):
-        """ Should be able to init without these values """
-        c = Configure()
-        Configureable.conf = c
-        d = Data()
-        try:
-            d.openDatabase()
-        except:
-            self.fail("Bad state")
-
-    def test_ZODB_persistence(self):
-        """ Should be able to init without these values """
-        c = Configure()
-        fname ='ZODB.fs'
-        c['rdf.source'] = 'ZODB'
-        c['rdf.store_conf'] = fname
-        Configureable.conf = c
-        d = Data()
-        try:
-            d.openDatabase()
-            g = make_graph(20)
-            for x in g:
-                d['rdf.graph'].add(x)
-            d.closeDatabase()
-
-            d.openDatabase()
-            self.assertEqual(20, len(list(d['rdf.graph'])))
-            d.closeDatabase()
-        except:
-            traceback.print_exc()
-            self.fail("Bad state")
-        delete_zodb_data_store(fname)
-
-    @unittest.skipIf((has_bsddb==False), "Sleepycat requires working bsddb")
-    def test_Sleepycat_persistence(self):
-        """ Should be able to init without these values """
-        c = Configure()
-        fname='Sleepycat_store'
-        c['rdf.source'] = 'Sleepycat'
-        c['rdf.store_conf'] = fname
-        Configureable.conf = c
-        d = Data()
-        try:
-            d.openDatabase()
-            g = make_graph(20)
-            for x in g:
-                d['rdf.graph'].add(x)
-            d.closeDatabase()
-
-            d.openDatabase()
-            self.assertEqual(20, len(list(d['rdf.graph'])))
-            d.closeDatabase()
-        except:
-            traceback.print_exc()
-            self.fail("Bad state")
-
-        subprocess.call("rm -rf "+fname, shell=True)
-
-    def test_trix_source(self):
-        """ Test that we can load the datbase up from an XML file.
-        """
-        f = tempfile.mkstemp()
-
-        c = Configure()
-        c['rdf.source'] = 'trix'
-        c['rdf.store'] = 'default'
-        c['trix_location'] = f[1]
-
-        with open(f[1],'w') as fo:
-            fo.write(TD.TriX_data)
-
-        connect(conf=c)
-        c = config()
-
-        try:
-            g = c['rdf.graph']
-            b = g.query("ASK { ?S ?P ?O }")
-            for x in b:
-                self.assertTrue(x)
-        except ImportError:
-            pass
-        finally:
-            disconnect()
-        os.unlink(f[1])
-
-    def test_trig_source(self):
-        """ Test that we can load the datbase up from a trig file.
-        """
-        f = tempfile.mkstemp()
-
-        c = Configure()
-        c['rdf.source'] = 'serialization'
-        c['rdf.serialization'] = f[1]
-        c['rdf.serialization_format'] = 'trig'
-        c['rdf.store'] = 'default'
-        with open(f[1],'w') as fo:
-            fo.write(TD.Trig_data)
-
-        connect(conf=c)
-        c = config()
-
-        try:
-            g = c['rdf.graph']
-            b = g.query("ASK { ?S ?P ?O }")
-            for x in b:
-                self.assertTrue(x)
-        except ImportError:
-            pass
-        finally:
-            disconnect()
 
 class PropertyTest(_DataTest):
     def test_one(self):
@@ -1064,6 +813,23 @@ class SimplePropertyTest(_DataTest):
 
 class NeuroMLTest(_DataTest):
     pass
+
+# Need description of these tests
+from DataTest import DataTest
+
+# Need description of these tests
+from RDFLibTest import RDFLibTest
+
+#class TimeTest(unittest.TestCase):
+    #def test_datetime_isoformat_has_timezone(self):
+        #time_stamp = now(utc).isoformat()
+        #self.assertRegexpMatches(time_stamp, r'.*[+-][0-9][0-9]:[0-9][0-9]$')
+
+# Need description of these tests
+from PintTest import PintTest
+
+# Need description of these tests
+from QuantityTest import QuantityTest
 
 class DocumentationTest(unittest.TestCase):
     def test_readme(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -16,6 +16,7 @@ import os
 import subprocess as SP
 import subprocess
 import tempfile
+import doctest
 
 from glob import glob
 
@@ -54,7 +55,6 @@ def delete_zodb_data_store(path):
     os.unlink(path + '.index')
     os.unlink(path + '.tmp')
     os.unlink(path + '.lock')
-
 
 class ExampleRunnerTest(unittest.TestCase):
     """ Try to run the examples to make sure we didn't break the API for them. """
@@ -139,7 +139,7 @@ class DataIntegrityTest(unittest.TestCase):
         """
         net = PyOpenWorm.Worm().get_neuron_network()
         self.assertEqual(302, len(set(net.neurons())))
-        
+
     @unittest.expectedFailure
     def test_TH_neuropeptide_neuron_list(self):
         """
@@ -1393,6 +1393,10 @@ class SimplePropertyTest(_DataTest):
 
 class NeuroMLTest(_DataTest):
     pass
+
+class DocumentationTest(unittest.TestCase):
+    def test_readme(self):
+        doctest.testfile("../README.md")
 
 if __name__ == '__main__':
     from optparse import OptionParser

--- a/tests/test.py
+++ b/tests/test.py
@@ -62,81 +62,14 @@ from ExampleRunnerTest import ExampleRunnerTest
 # Need description of these tests
 from DataIntegrityTest import DataIntegrityTest
 
-class ConfigureTest(unittest.TestCase):
-    def test_fake_config(self):
-        """ Try to retrieve a config value that hasn't been set """
-        with self.assertRaises(KeyError):
-            c = Configure()
-            c['not_a_valid_config']
+# Need description of these tests
+from ConfigureTest import ConfigureTest
 
-    def test_literal(self):
-        """ Assign a literal rather than a ConfigValue"""
-        c = Configure()
-        c['seven'] = "coke"
-        self.assertEqual(c['seven'], "coke")
+# Need description of these tests
+from ConfigureableTest import ConfigureableTest
 
-    def test_ConfigValue(self):
-        """ Assign a ConfigValue"""
-        c = Configure()
-        class pipe(ConfigValue):
-            def get(self):
-                return "sign"
-        c['seven'] = pipe()
-        self.assertEqual("sign",c['seven'])
-
-    def test_getter_no_ConfigValue(self):
-        """ Assign a method with a "get". Should return a the object rather than calling its get method """
-        c = Configure()
-        class pipe:
-            def get(self):
-                return "sign"
-        c['seven'] = pipe()
-        self.assertIsInstance(c['seven'], pipe)
-
-    def test_late_get(self):
-        """ "get" shouldn't be called until the value is *dereferenced* """
-        c = Configure()
-        a = {'t' : False}
-        class pipe(ConfigValue):
-            def get(self):
-                a['t'] = True
-                return "sign"
-        c['seven'] = pipe()
-        self.assertFalse(a['t'])
-        self.assertEqual(c['seven'], "sign")
-        self.assertTrue(a['t'])
-
-    def test_read_from_file(self):
-        """ Read configuration from a JSON file """
-        try:
-            d = Data.open("tests/test.conf")
-            self.assertEqual("test_value", d["test_variable"])
-        except:
-            self.fail("test.conf should exist and be valid JSON")
-
-    def test_read_from_file_fail(self):
-        """ Fail on attempt to read configuration from a non-JSON file """
-        with self.assertRaises(ValueError):
-            Data.open("tests/bad_test.conf")
-
-
-class ConfigureableTest(unittest.TestCase):
-    def test_init_empty(self):
-        """Ensure Configureable gets init'd with the defalut if nothing's given"""
-        i = Configureable()
-        self.assertEqual(Configureable.conf,i.conf)
-
-    def test_init_False(self):
-        """Ensure Configureable gets init'd with the defalut if False is given"""
-        i = Configureable(conf=False)
-        self.assertEqual(Configureable.conf, i.conf)
-
-class DataObjectTestToo(unittest.TestCase):
-    def test_helpful_message_on_non_connection(self):
-        """ The message should say something about connecting """
-        Configureable.conf = False # Ensure that we are disconnected
-        with self.assertRaisesRegexp(Exception, ".*[cC]onnect.*"):
-            do = DataObject()
+# Need description of these tests
+from DataObjectTestToo import DataObjectTestToo
 
 class _DataTest(unittest.TestCase):
     def delete_dir(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -56,274 +56,87 @@ def delete_zodb_data_store(path):
     os.unlink(path + '.tmp')
     os.unlink(path + '.lock')
 
-class ExampleRunnerTest(unittest.TestCase):
-    """ Try to run the examples to make sure we didn't break the API for them. """
+# Need description of these tests
+from ExampleRunnerTest import ExampleRunnerTest
 
-    #Currently these are all failing because we aren't reproducing the actual data that
-    # a user gets when they grab the code for the first time
+# Need description of these tests
+from DataIntegrityTest import DataIntegrityTest
 
-    @classmethod
-    def setUpClass(self):
-        PyOpenWorm.connect()
-        PyOpenWorm.loadData(skipIfNewer=False)
-        PyOpenWorm.disconnect()
-        os.chdir('examples')
+class ConfigureTest(unittest.TestCase):
+    def test_fake_config(self):
+        """ Try to retrieve a config value that hasn't been set """
+        with self.assertRaises(KeyError):
+            c = Configure()
+            c['not_a_valid_config']
 
-    @classmethod
-    def tearDownClass(self):
-        os.chdir('..')
+    def test_literal(self):
+        """ Assign a literal rather than a ConfigValue"""
+        c = Configure()
+        c['seven'] = "coke"
+        self.assertEqual(c['seven'], "coke")
 
-    def execfile(self, example_file_name):
-        fname = tempfile.mkstemp()[1]
-        with open(fname, 'w+') as out:
-            stat = SP.call(["python", example_file_name], stdout=out, stderr=out)
-            out.seek(0)
-            self.assertEqual(0, stat, out.read())
-        os.unlink(fname)
+    def test_ConfigValue(self):
+        """ Assign a ConfigValue"""
+        c = Configure()
+        class pipe(ConfigValue):
+            def get(self):
+                return "sign"
+        c['seven'] = pipe()
+        self.assertEqual("sign",c['seven'])
 
-    def test_run_NeuronBasicInfo(self):
-        self.execfile("NeuronBasicInfo.py")
+    def test_getter_no_ConfigValue(self):
+        """ Assign a method with a "get". Should return a the object rather than calling its get method """
+        c = Configure()
+        class pipe:
+            def get(self):
+                return "sign"
+        c['seven'] = pipe()
+        self.assertIsInstance(c['seven'], pipe)
 
-    def test_run_NetworkInfo(self):
-        # XXX: No `synclass' is given, so all neurons are called `excitatory'
-        self.execfile("NetworkInfo.py")
+    def test_late_get(self):
+        """ "get" shouldn't be called until the value is *dereferenced* """
+        c = Configure()
+        a = {'t' : False}
+        class pipe(ConfigValue):
+            def get(self):
+                a['t'] = True
+                return "sign"
+        c['seven'] = pipe()
+        self.assertFalse(a['t'])
+        self.assertEqual(c['seven'], "sign")
+        self.assertTrue(a['t'])
 
-    @unittest.expectedFailure
-    def test_run_morpho(self):
-        self.execfile("morpho.py")
+    def test_read_from_file(self):
+        """ Read configuration from a JSON file """
+        try:
+            d = Data.open("tests/test.conf")
+            self.assertEqual("test_value", d["test_variable"])
+        except:
+            self.fail("test.conf should exist and be valid JSON")
 
-    def test_gap_junctions(self):
-        self.execfile("gap_junctions.py")
+    def test_read_from_file_fail(self):
+        """ Fail on attempt to read configuration from a non-JSON file """
+        with self.assertRaises(ValueError):
+            Data.open("tests/bad_test.conf")
 
-    def test_add_reference(self):
-        self.execfile("add_reference.py")
 
-    def test_bgp(self):
-        self.execfile("test_bgp.py")
+class ConfigureableTest(unittest.TestCase):
+    def test_init_empty(self):
+        """Ensure Configureable gets init'd with the defalut if nothing's given"""
+        i = Configureable()
+        self.assertEqual(Configureable.conf,i.conf)
 
-    def test_rmgr(self):
-        self.execfile("rmgr.py")
+    def test_init_False(self):
+        """Ensure Configureable gets init'd with the defalut if False is given"""
+        i = Configureable(conf=False)
+        self.assertEqual(Configureable.conf, i.conf)
 
-class DataIntegrityTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        import csv
-
-        cls.neurons = [] #array that holds the names of the 302 neurons at class-level scope
-
-        if not USE_BINARY_DB:
-            PyOpenWorm.connect(conf=Data()) # Connect for integrity tests that use PyOpenWorm functions
-            cls.g = PyOpenWorm.config('rdf.graph') # declare class-level scope for the database
-            cls.g.parse("OpenWormData/WormData.n3", format="n3") # load in the database
-        else:
-            conf = Configure(**{ "rdf.source" : "ZODB", "rdf.store_conf" : BINARY_DB })
-            PyOpenWorm.connect(conf=conf)
-            cls.g = PyOpenWorm.config('rdf.graph')
-
-        #grab the list of the names of the 302 neurons
-
-        csvfile = open('OpenWormData/aux_data/neurons.csv', 'r')
-        reader = csv.reader(csvfile, delimiter=';', quotechar='|')
-
-        for row in reader:
-            if len(row[0]) > 0: # Only saves valid neuron names
-                cls.neurons.append(row[0])
-    @classmethod
-    def tearDownClass(cls):
-        PyOpenWorm.disconnect()
-
-    @unittest.expectedFailure
-    def test_correct_neuron_number(self):
-        """
-        This test verifies that the worm model has exactly 302 neurons.
-        """
-        net = PyOpenWorm.Worm().get_neuron_network()
-        self.assertEqual(302, len(set(net.neurons())))
-
-    @unittest.expectedFailure
-    def test_TH_neuropeptide_neuron_list(self):
-        """
-        This test verifies that the set of neurons which contain the
-        neuropeptide TH is correct (the list is given below).
-        """
-        neuronlist = PyOpenWorm.Neuron()
-        neuronlist.neuropeptide("TH")
-        thlist = set(x.name() for x in neuronlist.load())
-        self.assertEqual(set(['CEPDR', 'PDER', 'CEPDL', 'PDEL', 'CEPVR', 'CEPVL']), thlist)
-
-    def testUniqueNeuronNode(self):
-        """
-        There should one and only one unique RDF node for every neuron.  If more than one is present for a given cell name,
-        then our data is inconsistent.  If there is not at least one present, then we are missing neurons.
-        """
-
-        results = {}
-        for n in self.neurons:
-            #Create a SPARQL query per neuron that looks for all RDF nodes that have text matching the name of the neuron
-            qres = self.g.query('SELECT distinct ?n WHERE {?n ?t ?s . ?s ?p \"' + n + '\" } LIMIT 5')
-            results[n] = (len(qres.result), [x[0] for x in qres.result])
-
-        # If there is not only one result back, then there is more than one RDF node.
-        more_than_one = [(x, results[x]) for x in results if results[x][0] > 1]
-        less_than_one = [(x, results[x]) for x in results if results[x][0] < 1]
-        self.assertEqual(0, len(more_than_one), "Some neurons have more than 1 node: " + "\n".join(str(x) for x in more_than_one))
-        self.assertEqual(0, len(less_than_one), "Some neurons have no node: " + "\n".join(str(x) for x in less_than_one))
-
-    def testNeuronsHaveTypes(self):
-        """
-        Every Neuron should have a non-blank type
-        """
-        results = set()
-        for n in self.neurons:
-            qres = self.g.query('SELECT ?v WHERE { ?s <http://openworm.org/entities/SimpleProperty/value> \"' + n + '\". ' #per node ?s that has the name of a neuron associated
-                                + '?k <http://openworm.org/entities/Cell/name> ?s .'
-                                + '?k <http://openworm.org/entities/Neuron/type> ?o .' #look up its listed type ?o
-                                + '?o <http://openworm.org/entities/SimpleProperty/value> ?v } ' #for that type ?o, get its property ?tp and its value ?v
-                                )
-            for x in qres:
-                v = x[0]
-                if isinstance(v,R.Literal):
-                    results.add(n)
-
-        # NOTE: Neurons ALNL, CANL, CANR, ALNR have unknown function and type
-        self.assertEqual(len(results), len(self.neurons) - 4, "Some neurons are missing a type: {}".format(set(self.neurons) - results))
-
-    def test_neuron_GJ_degree(self):
-        """ Get the number of gap junctions from a networkx representation """
-        self.assertEqual(PyOpenWorm.Neuron(name='AVAL').GJ_degree(), 40)
-
-    def test_neuron_Syn_degree(self):
-        """ Get the number of chemical synapses from a networkx representation """
-        # XXX: This result is 1 greater compared to what would be expected from the
-        # connectome.csv file
-        self.assertEqual(PyOpenWorm.Neuron(name='AVAL').Syn_degree(), 91)
-
-    @unittest.skip("have not yet defined asserts")
-    def testWhatNodesGetTypeInfo(self):
-        qres = self.g.query('SELECT ?o ?p ?s WHERE {'
-                                + '?o <http://openworm.org/entities/SimpleProperty/value> "motor". '
-                                  '?o ?p ?s} ' #for that type ?o, get its value ?v
-                                + 'LIMIT 10')
-        for row in qres.result:
-            print row
-
-    @unittest.expectedFailure
-    def test_compare_to_xls(self):
-        """ Compare the PyOpenWorm connections to the data in the spreadsheet """
-        SAMPLE_CELL = 'ADAL'
-        xls_conns = []
-        pow_conns = []
-
-        #QUERY TO GET ALL CONNECTIONS WHERE SAMPLE_CELL IS ON THE PRE SIDE
-        qres = self.g.query("""SELECT ?post_name ?type (STR(?num) AS ?numval) WHERE {
-                               #############################################################
-                               # Find connections that have the ?pre_name as our passed in value
-                               #############################################################
-                               ?pre_namenode <http://openworm.org/entities/SimpleProperty/value> \'"""
-                               + SAMPLE_CELL +
-                               """\'.
-                               ?pre_cell <http://openworm.org/entities/Cell/name> ?pre_namenode.
-                               ?pre <http://openworm.org/entities/SimpleProperty/value> ?pre_cell.
-                               ?conn <http://openworm.org/entities/Connection/pre_cell> ?pre.
-
-                               #############################################################
-                               # Find all the cells that are on the post side of those
-                               #  connections and bind their names to ?post_name
-                               #############################################################
-                               ?conn <http://openworm.org/entities/Connection/post_cell> ?post.
-                               ?post <http://openworm.org/entities/SimpleProperty/value> ?post_cell.
-                               ?post_cell <http://openworm.org/entities/Cell/name> ?post_namenode.
-                               ?post_namenode <http://openworm.org/entities/SimpleProperty/value> ?post_name.
-
-                               ############################################################
-                               # Go find the type of the connection and bind to ?type
-                               #############################################################
-                               ?conn <http://openworm.org/entities/Connection/syntype> ?syntype_node.
-                               ?syntype_node <http://openworm.org/entities/SimpleProperty/value> ?type.
-
-                               ############################################################
-                               # Go find the number of the connection and bind to ?num
-                               ############################################################
-                               ?conn <http://openworm.org/entities/Connection/number> ?number_node.
-                               ?number_node <http://openworm.org/entities/SimpleProperty/value> ?num.
-
-                               ############################################################
-                               # Filter out any ?pre_names or ?post_names that aren't literals
-                               ############################################################
-                               FILTER(isLiteral(?post_name))}""")
-        def ff(x):
-            return str(x.value)
-        for line in qres.result:
-            t = list(map(ff, line))
-            t.insert(0,SAMPLE_CELL) #Insert sample cell name into the result set after the fact
-            pow_conns.append(t)
-
-        #QUERY TO GET ALL CONNECTIONS WHERE SAMPLE_CELL IS ON THE *POST* SIDE
-        qres = self.g.query("""SELECT ?pre_name ?type (STR(?num) AS ?numval) WHERE {
-                               #############################################################
-                               # Find connections that have the ?post_name as our passed in value
-                               #############################################################
-                               ?post_namenode <http://openworm.org/entities/SimpleProperty/value> \'"""
-                               + SAMPLE_CELL +
-                               """\'.
-                               ?post_cell <http://openworm.org/entities/Cell/name> ?post_namenode.
-                               ?post <http://openworm.org/entities/SimpleProperty/value> ?post_cell.
-                               ?conn <http://openworm.org/entities/Connection/post_cell> ?post.
-
-                               #############################################################
-                               # Find all the cells that are on the pre side of those
-                               #  connections and bind their names to ?pre_name
-                               #############################################################
-                               ?conn <http://openworm.org/entities/Connection/pre_cell> ?pre.
-                               ?pre <http://openworm.org/entities/SimpleProperty/value> ?pre_cell.
-                               ?pre_cell <http://openworm.org/entities/Cell/name> ?pre_namenode.
-                               ?pre_namenode <http://openworm.org/entities/SimpleProperty/value> ?pre_name.
-
-                               ############################################################
-                               # Go find the type of the connection and bind to ?type
-                               #############################################################
-                               ?conn <http://openworm.org/entities/Connection/syntype> ?syntype_node.
-                               ?syntype_node <http://openworm.org/entities/SimpleProperty/value> ?type.
-
-                               ############################################################
-                               # Go find the number of the connection and bind to ?num
-                               ############################################################
-                               ?conn <http://openworm.org/entities/Connection/number> ?number_node.
-                               ?number_node <http://openworm.org/entities/SimpleProperty/value> ?num.
-
-                               ############################################################
-                               # Filter out any ?pre_names or ?post_names that aren't literals
-                               ############################################################
-                               FILTER(isLiteral(?pre_name))}""")
-        for line in qres.result:
-            t = list(map(ff, line))
-            t.insert(1,SAMPLE_CELL) #Insert sample cell name into the result set after the fact
-            pow_conns.append(t)
-
-        #Get connections from the sheet
-        import xlrd
-        wb = xlrd.open_workbook('OpenWormData/aux_data/NeuronConnect.xls')
-        sheet = wb.sheets()[0]
-        #Put every ADAL connection (except EMJs and Rs!) in a list as a tuple. This helps us compare them later
-        def floatToStr(x):
-            return str(int(x.value))
-        def sendOrGj(x):
-            if x.value == 'EJ':
-                return 'gapJunction'
-            else:
-                return 'send'
-
-        for row in range(1, sheet.nrows):
-            if SAMPLE_CELL in [sheet.cell(row, 0).value, sheet.cell(row, 1).value] and sheet.cell(row, 2).value in ['S', 'Sp', 'EJ']:
-                string_row = [str(sheet.cell(row, 0).value), str(sheet.cell(row, 1).value), sendOrGj(sheet.cell(row, 2)), floatToStr(sheet.cell(row, 3))]
-                t = list(string_row)
-                xls_conns.append(t)
-
-        #assert that these two sorted lists are the same
-        #using sorted lists because Set() removes multiples
-
-        self.maxDiff = None
-        self.assertEqual(sorted(pow_conns), sorted(xls_conns))
+class DataObjectTestToo(unittest.TestCase):
+    def test_helpful_message_on_non_connection(self):
+        """ The message should say something about connecting """
+        Configureable.conf = False # Ensure that we are disconnected
+        with self.assertRaisesRegexp(Exception, ".*[cC]onnect.*"):
+            do = DataObject()
 
 class _DataTest(unittest.TestCase):
     def delete_dir(self):
@@ -398,74 +211,6 @@ class WormTest(_DataTest):
     def test_get_semantic_net(self):
         g0 = Worm().get_semantic_net()
         self.assertTrue(isinstance(g0, rdflib.ConjunctiveGraph))
-
-class ConfigureTest(unittest.TestCase):
-    def test_fake_config(self):
-        """ Try to retrieve a config value that hasn't been set """
-        with self.assertRaises(KeyError):
-            c = Configure()
-            c['not_a_valid_config']
-
-    def test_literal(self):
-        """ Assign a literal rather than a ConfigValue"""
-        c = Configure()
-        c['seven'] = "coke"
-        self.assertEqual(c['seven'], "coke")
-
-    def test_ConfigValue(self):
-        """ Assign a ConfigValue"""
-        c = Configure()
-        class pipe(ConfigValue):
-            def get(self):
-                return "sign"
-        c['seven'] = pipe()
-        self.assertEqual("sign",c['seven'])
-
-    def test_getter_no_ConfigValue(self):
-        """ Assign a method with a "get". Should return a the object rather than calling its get method """
-        c = Configure()
-        class pipe:
-            def get(self):
-                return "sign"
-        c['seven'] = pipe()
-        self.assertIsInstance(c['seven'], pipe)
-
-    def test_late_get(self):
-        """ "get" shouldn't be called until the value is *dereferenced* """
-        c = Configure()
-        a = {'t' : False}
-        class pipe(ConfigValue):
-            def get(self):
-                a['t'] = True
-                return "sign"
-        c['seven'] = pipe()
-        self.assertFalse(a['t'])
-        self.assertEqual(c['seven'], "sign")
-        self.assertTrue(a['t'])
-
-    def test_read_from_file(self):
-        """ Read configuration from a JSON file """
-        try:
-            d = Data.open("tests/test.conf")
-            self.assertEqual("test_value", d["test_variable"])
-        except:
-            self.fail("test.conf should exist and be valid JSON")
-
-    def test_read_from_file_fail(self):
-        """ Fail on attempt to read configuration from a non-JSON file """
-        with self.assertRaises(ValueError):
-            Data.open("tests/bad_test.conf")
-
-class ConfigureableTest(unittest.TestCase):
-    def test_init_empty(self):
-        """Ensure Configureable gets init'd with the defalut if nothing's given"""
-        i = Configureable()
-        self.assertEqual(Configureable.conf,i.conf)
-
-    def test_init_False(self):
-        """Ensure Configureable gets init'd with the defalut if False is given"""
-        i = Configureable(conf=False)
-        self.assertEqual(Configureable.conf, i.conf)
 
 class CellTest(_DataTest):
 
@@ -611,13 +356,6 @@ class DataObjectTest(_DataTest):
         r.save()
         u = r.upload_date()
         self.assertIsNotNone(u)
-
-class DataObjectTestToo(unittest.TestCase):
-    def test_helpful_message_on_non_connection(self):
-        """ The message should say something about connecting """
-        Configureable.conf = False # Ensure that we are disconnected
-        with self.assertRaisesRegexp(Exception, ".*[cC]onnect.*"):
-            do = DataObject()
 
 class DataUserTest(_DataTest):
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -131,14 +131,16 @@ class DataIntegrityTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         PyOpenWorm.disconnect()
-        
+
+    @unittest.expectedFailure
     def test_correct_neuron_number(self):
         """
         This test verifies that the worm model has exactly 302 neurons.
         """
         net = PyOpenWorm.Worm().get_neuron_network()
         self.assertEqual(302, len(set(net.neurons())))
-
+        
+    @unittest.expectedFailure
     def test_TH_neuropeptide_neuron_list(self):
         """
         This test verifies that the set of neurons which contain the

--- a/tests/test.py
+++ b/tests/test.py
@@ -131,6 +131,23 @@ class DataIntegrityTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         PyOpenWorm.disconnect()
+        
+    def test_correct_neuron_number(self):
+        """
+        This test verifies that the worm model has exactly 302 neurons.
+        """
+        net = PyOpenWorm.Worm().get_neuron_network()
+        self.assertEqual(302, len(set(net.neurons())))
+
+    def test_TH_neuropeptide_neuron_list(self):
+        """
+        This test verifies that the set of neurons which contain the
+        neuropeptide TH is correct (the list is given below).
+        """
+        neuronlist = PyOpenWorm.Neuron()
+        neuronlist.neuropeptide("TH")
+        thlist = set(x.name() for x in neuronlist.load())
+        self.assertEqual(set(['CEPDR', 'PDER', 'CEPDL', 'PDEL', 'CEPVR', 'CEPVL']), thlist)
 
     def testUniqueNeuronNode(self):
         """


### PR DESCRIPTION
With @travs:
1) Made separate files for each test class, with the exception of anything that inherited from _DataTest
2) All _DataTest related classes were kept in test.py- we can work on these separately if this pull request is approved
3) This pull request already incorporates the changes made separately which allow for doctests to be run from test.py.  See #110 