### PR TITLE
Tally doctests alongside ordinary unit tests.  Fixes #109.  

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -831,10 +831,6 @@ from PintTest import PintTest
 # Need description of these tests
 from QuantityTest import QuantityTest
 
-class DocumentationTest(unittest.TestCase):
-    def test_readme(self):
-        doctest.testfile("../README.md")
-
 if __name__ == '__main__':
     from optparse import OptionParser
     parser = OptionParser()
@@ -879,5 +875,10 @@ if __name__ == '__main__':
         suite.addTests(filter(lambda x: x.id().startswith("__main__."+args[0]), all_tests_flattened))
     else:
         suite.addTests(all_tests)
+
+    #Add doctest to the test suite.
+    READMETestSuite = doctest.DocFileSuite("../README.md")
+    suite.addTests(READMETestSuite)
+
     res = runTests(suite)
     sys.exit(len(res.failures)>0)

--- a/tests/test.py
+++ b/tests/test.py
@@ -831,6 +831,13 @@ from PintTest import PintTest
 # Need description of these tests
 from QuantityTest import QuantityTest
 
+# Tests from README.md
+class DocumentationTest(unittest.TestCase):
+    @unittest.expectedFailure
+    def test_readme(self):
+        [failure_count, return_count] = doctest.testfile("../README.md")
+        self.assertEqual(failure_count, 0)
+
 if __name__ == '__main__':
     from optparse import OptionParser
     parser = OptionParser()
@@ -875,10 +882,6 @@ if __name__ == '__main__':
         suite.addTests(filter(lambda x: x.id().startswith("__main__."+args[0]), all_tests_flattened))
     else:
         suite.addTests(all_tests)
-
-    #Add doctest to the test suite.
-    READMETestSuite = doctest.DocFileSuite("../README.md")
-    suite.addTests(READMETestSuite)
 
     res = runTests(suite)
     sys.exit(len(res.failures)>0)


### PR DESCRIPTION
With @travs:
1) Created a proper test suite from README doctests
2) The total number of tests does not change, but this is a step towards exposing individual tests with the new breakdown of test.py