### PR TITLE
Fail build when there are errors during testing

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -883,4 +883,4 @@ if __name__ == '__main__':
         suite.addTests(all_tests)
 
     res = runTests(suite)
-    sys.exit(len(res.failures)>0)
+    sys.exit(len(res.failures + res.errors)>0)


### PR DESCRIPTION
The build would pass previously if there were no test failures. Now it
will fail when there are errors during testing as well, which is still
valuable information.

See #144