### PR TITLE
Rebase #240

### DIFF
--- a/PyOpenWorm/network.py
+++ b/PyOpenWorm/network.py
@@ -21,7 +21,7 @@ class Network(DataObject):
 
     def neurons(self):
         """
-        Gets the complete set of neurons in this network.
+        Gets the complete set of neurons' names in this network.
 
         Example::
 

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -284,11 +284,10 @@ class DataIntegrityTest(unittest.TestCase):
         for muscle_object in muscles:
             self.assertNotEqual(muscle_object.wormbaseID(), '')
 
-    @unittest.expectedFailure
     def test_all_neurons_are_cells(self):
         """ This test verifies that all Neuron objects are also Cell objects. """
         net = PyOpenWorm.Worm().get_neuron_network()
-        for neuron_object in net.neurons():
+        for neuron_object in net.neuron():
             assert isinstance(neuron_object, PyOpenWorm.Cell)
 
     def test_all_muscles_are_cells(self):

--- a/tests/NetworkTest.py
+++ b/tests/NetworkTest.py
@@ -34,8 +34,8 @@ class NetworkTest(_DataTest):
 
     def test_neurons(self):
         """
-        Test that we can access arbitrary Neurons,
-        and that they are in the Network
+        Test that we can add arbitrary Neurons to the Network,
+        and that they can be accessed afterwards.
         """
         self.net.neuron(Neuron(name='AVAL'))
         self.net.neuron(Neuron(name='DD5'))
@@ -51,4 +51,3 @@ class NetworkTest(_DataTest):
     def test_as_networkx(self):
         """Test that as_networkx returns the correct type."""
         self.assertTrue(isinstance(self.net.as_networkx(),networkx.DiGraph))
-


### PR DESCRIPTION
This is just a rebase of @signija's original PR #240.

She said:
> Corrected `test_all_neurons_are_cells` in DataIntegrityTest.
Additionally: updated descriptions of `test_neurons` in NetworkTest, and `Network.neurons()`. Descriptions are interpretable, so I changed it to what I personally found most suitable. Can be changed if still unclear, of course.
> (note: the relevant commits are only the last 3, the rest have been reverted.)

Fix #228 