### PR TITLE
Connected to #178

### DIFF
--- a/OpenWormData/scripts/insert_worm.py
+++ b/OpenWormData/scripts/insert_worm.py
@@ -235,7 +235,7 @@ def new_connections():
     try:
         w = P.Worm()
         n = P.Network()
-        neurons = set(n.neurons())
+        neurons = set(n.neuron_names())
         w.neuron_network(n)
 
         # Evidence object to assert each connection

--- a/OpenWormData/scripts/insert_worm.py
+++ b/OpenWormData/scripts/insert_worm.py
@@ -122,7 +122,7 @@ def upload_lineage_and_descriptions():
             n.description(cell_data['desc'])
             w.cell(n)
 
-        for n in net.neuron():
+        for n in net.neurons():
             add_data_to_cell(n)
 
         # TODO: Add data for other cells here. Requires relating named

--- a/PyOpenWorm/network.py
+++ b/PyOpenWorm/network.py
@@ -35,7 +35,7 @@ class Network(DataObject):
             set(['VB4', 'PDEL', 'HSNL', 'SIBDR', ... 'RIAL', 'MCR', 'LUAL'])
 
         """
-        for x in self.neuron():
+        for x in self.neurons():
             yield x.name()
 
     def aneuron(self, name):

--- a/PyOpenWorm/network.py
+++ b/PyOpenWorm/network.py
@@ -19,7 +19,7 @@ class Network(DataObject):
         self.synapses = Network.ObjectProperty('synapse', owner=self, value_type=P.Connection, multiple=True)
         Network.ObjectProperty('neuron',owner=self,value_type=P.Neuron, multiple=True)
 
-    def neurons(self):
+    def neuron_names(self):
         """
         Gets the complete set of neurons in this network.
 
@@ -29,9 +29,9 @@ class Network(DataObject):
             >>> net = P.Worm().get_neuron_network()
 
             #NOTE: This is a VERY slow operation right now
-            >>> len(set(net.neurons()))
+            >>> len(set(net.neuron_names()))
             302
-            >>> set(net.neurons())
+            >>> set(net.neuron_names())
             set(['VB4', 'PDEL', 'HSNL', 'SIBDR', ... 'RIAL', 'MCR', 'LUAL'])
 
         """

--- a/PyOpenWorm/network.py
+++ b/PyOpenWorm/network.py
@@ -9,9 +9,9 @@ class Network(DataObject):
     Attributes
     -----------
     neuron
-        Representation of neurons in the network
+        Returns a set of all Neuron objects in the network
     synapse
-        Representation of synapses in the network
+        Returns a set of all synapses in the network
     """
     def __init__(self, **kwargs):
         DataObject.__init__(self,**kwargs)

--- a/PyOpenWorm/network.py
+++ b/PyOpenWorm/network.py
@@ -17,7 +17,7 @@ class Network(DataObject):
         DataObject.__init__(self,**kwargs)
 
         self.synapses = Network.ObjectProperty('synapse', owner=self, value_type=P.Connection, multiple=True)
-        Network.ObjectProperty('neuron',owner=self,value_type=P.Neuron, multiple=True)
+        self.neurons = Network.ObjectProperty('neuron',owner=self,value_type=P.Neuron, multiple=True)
 
     def neuron_names(self):
         """

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ Returns the list of all neurons::
 
 ```python
 #NOTE: This is a VERY slow operation right now
->>> len(set(net.neurons()))
+>>> len(set(net.neuron_names()))
 302
->>> sorted(list(net.neurons())) # doctest:+ELLIPSIS
+>>> sorted(list(net.neuron_names())) # doctest:+ELLIPSIS
 [u'ADAL', u'ADAR', ... u'VD8', u'VD9']
 
 ```

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -57,7 +57,7 @@ class DataIntegrityTest(unittest.TestCase):
         This test verifies that the worm model has exactly 302 neurons.
         """
         net = PyOpenWorm.Worm().get_neuron_network()
-        self.assertEqual(302, len(set(net.neurons())))
+        self.assertEqual(302, len(set(net.neuron_names())))
 
     def test_TH_neuropeptide_neuron_list(self):
         """
@@ -274,7 +274,7 @@ class DataIntegrityTest(unittest.TestCase):
     def test_all_neurons_have_wormbaseID(self):
         """ This test verifies that every neuron has a Wormbase ID. """
         net = PyOpenWorm.Worm().get_neuron_network()
-        for neuron_object in net.neurons():
+        for neuron_object in net.neuron():
             self.assertNotEqual(neuron_object.wormbaseID(), '')
 
     @unittest.expectedFailure

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -274,7 +274,7 @@ class DataIntegrityTest(unittest.TestCase):
     def test_all_neurons_have_wormbaseID(self):
         """ This test verifies that every neuron has a Wormbase ID. """
         net = PyOpenWorm.Worm().get_neuron_network()
-        for neuron_object in net.neuron():
+        for neuron_object in net.neurons():
             self.assertNotEqual(neuron_object.wormbaseID(), '')
 
     @unittest.expectedFailure

--- a/tests/EvidenceCoverageTest.py
+++ b/tests/EvidenceCoverageTest.py
@@ -28,7 +28,7 @@ class EvidenceCoverageTest(_DataTest):
         """ For each neuron in PyOpenWorm, verify
         that there is supporting evidence"""
         net = Worm().neuron_network()
-        neurons = list(net.neuron())
+        neurons = list(net.neurons())
         evcheck = []
         for n in neurons:
             hasEvidence = len(get_supporting_evidence(nobj))

--- a/tests/EvidenceCoverageTest.py
+++ b/tests/EvidenceCoverageTest.py
@@ -28,7 +28,7 @@ class EvidenceCoverageTest(_DataTest):
         """ For each neuron in PyOpenWorm, verify
         that there is supporting evidence"""
         net = Worm().neuron_network()
-        neurons = list(net.neurons())
+        neurons = list(net.neuron())
         evcheck = []
         for n in neurons:
             hasEvidence = len(get_supporting_evidence(nobj))

--- a/tests/MiscTest.py
+++ b/tests/MiscTest.py
@@ -34,7 +34,7 @@ class MiscTest(_DataTest):
         """
 
         net = Worm().neuron_network()
-        neurons = net.neurons()
+        neurons = net.neuron_names()
         check1 = len(list(neurons))
         check2 = len(list(neurons))
         self.assertEqual(check1, check2)

--- a/tests/NetworkTest.py
+++ b/tests/NetworkTest.py
@@ -39,8 +39,8 @@ class NetworkTest(_DataTest):
         """
         self.net.neuron(Neuron(name='AVAL'))
         self.net.neuron(Neuron(name='DD5'))
-        self.assertTrue('AVAL' in self.net.neurons())
-        self.assertTrue('DD5' in self.net.neurons())
+        self.assertTrue('AVAL' in self.net.neuron_names())
+        self.assertTrue('DD5' in self.net.neuron_names())
 
     def test_synapses_rdf(self):
         """ Check that synapses() returns connection objects """


### PR DESCRIPTION
Based on the discussion in #178 : renamed `Network.neurons()` to `Network.neuron_names()`, updated calls of the function, aliased `Network.neurons` to return the same thing as `Network.neuron`, and updated the docstring for the Network class.