### PR TITLE
Data integrity tests for the new connectome

### DIFF
--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -343,6 +343,7 @@ class DataIntegrityTest(unittest.TestCase):
 
         self.assertTrue(csv_tuples.issubset(synapse_tuples))
 
+    @unittest.expectedFailure
     def test_number_neuron_to_neuron(self):
         """
         This test verifies that the worm model has exactly 5805 neuron to neuron connections.
@@ -356,6 +357,7 @@ class DataIntegrityTest(unittest.TestCase):
 
         self.assertEqual(5805, count)
 
+    @unittest.expectedFailure
     def test_number_neuron_to_muscle(self):
         """
         This test verifies that the worm model has exactly 1111 neuron to muscle connections.

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -59,6 +59,13 @@ class DataIntegrityTest(unittest.TestCase):
         net = PyOpenWorm.Worm().get_neuron_network()
         self.assertEqual(302, len(set(net.neuron_names())))
 
+    def test_correct_muscle_number(self):
+        """
+        This test verifies that the worm model has exactly 144 muscles.
+        """
+        muscles = P.Worm().muscles()
+        self.assertEqual(144, len(muscles))
+
     def test_TH_neuropeptide_neuron_list(self):
         """
         This test verifies that the set of neurons which contain the
@@ -307,9 +314,12 @@ class DataIntegrityTest(unittest.TestCase):
     def test_connection_content_matches(self):
         """ This test verifies that the content of each connection matches the
         content in the source. """
-        synapses = PyOpenWorm.Worm().get_neuron_network().synapses()
-        ignored_cells = ['hyp', 'intestine']
+        ignored_cells = ['HYP', 'INTESTINE']
         unmatched = 0
+
+        # get a sorted list of synapses
+        net = PyOpenWorm.Worm().get_neuron_network()
+        synapses = sorted(list(net.neurons()))
 
         # read csv file row by row
         with open('OpenWormData/aux_data/herm_full_edgelist.csv', 'rb') as csvfile:

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -386,3 +386,23 @@ class DataIntegrityTest(unittest.TestCase):
             unique_neurons.add(synapse.pre_cell())    # set won't count duplicates
 
         self.assertEqual(300, len(unique_neurons))
+
+    @unittest.expectedFailure
+    def test_unconnected_neurons(self):
+        """
+        This test verifies that there are exactly 2 unconnected neurons,
+        i.e., CANL and CANR, in the new connectome.
+        """
+        # In previous tests, there is a check for exactly 302 neurons in total.
+        # There is also a test for exactly 300 unique neurons making connections.
+        # That means it should be enough to check that the set {CANL, CANR} and
+        # the set of neurons making connections are disjoint.
+
+        synapses = PyOpenWorm.Worm().get_neuron_network().synapses()
+        connected_neurons = {}
+        unconnected_neurons = {'CANL', 'CANR'}
+
+        for synapse in synapses:
+            connected_neurons.add(synapse.pre_cell())
+
+        self.assertTrue(connected_neurons.isdisjoint(unconnected_neurons))

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -48,6 +48,7 @@ class DataIntegrityTest(unittest.TestCase):
         for row in reader:
             if len(row[0]) > 0: # Only saves valid neuron names
                 cls.neurons.append(row[0])
+
     @classmethod
     def tearDownClass(cls):
         PyOpenWorm.disconnect()
@@ -292,7 +293,6 @@ class DataIntegrityTest(unittest.TestCase):
         for muscle_object in muscles:
             self.assertNotEqual(muscle_object.wormbaseID(), '')
 
-    @unittest.expectedFailure
     def test_all_neurons_are_cells(self):
         """ This test verifies that all Neuron objects are also Cell objects. """
         net = PyOpenWorm.Worm().get_neuron_network()

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -63,7 +63,7 @@ class DataIntegrityTest(unittest.TestCase):
         """
         This test verifies that the worm model has exactly 144 muscles.
         """
-        muscles = P.Worm().muscles()
+        muscles = PyOpenWorm.Worm().muscles()
         self.assertEqual(144, len(muscles))
 
     def test_TH_neuropeptide_neuron_list(self):

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -299,10 +299,9 @@ class DataIntegrityTest(unittest.TestCase):
 
     @unittest.expectedFailure
     def test_correct_connections_number(self):
-        """ This test verifies that there are exactly 3225 connections. """
+        """ This test verifies that there are exactly 6916 connections. """
         net = PyOpenWorm.Worm().get_neuron_network()
-        #TODO Change the number of connections when the new connectome is ready.
-        self.assertEqual(3225, len(net.synapses())
+        self.assertEqual(6916, len(net.synapses()))
 
     @unittest.expectedFailure
     def test_connection_content_matches(self):

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -297,13 +297,13 @@ class DataIntegrityTest(unittest.TestCase):
         """ This test verifies that all Neuron objects are also Cell objects. """
         net = PyOpenWorm.Worm().get_neuron_network()
         for neuron_object in net.neurons():
-            assert isinstance(neuron_object, PyOpenWorm.Cell)
+            self.assertIsInstance(neuron_object, PyOpenWorm.Cell)
 
     def test_all_muscles_are_cells(self):
         """ This test verifies that all Muscle objects are also Cell objects. """
         muscles = PyOpenWorm.Worm().muscles()
         for muscle_object in muscles:
-            assert isinstance(muscle_object, PyOpenWorm.Cell)
+            self.assertIsInstance(muscle_object, PyOpenWorm.Cell)
 
     @unittest.expectedFailure
     def test_correct_connections_number(self):
@@ -341,7 +341,7 @@ class DataIntegrityTest(unittest.TestCase):
                 csv_tuple = (source, target, weight, syn_type)
                 csv_tuples.add(csv_tuple)
 
-        assert(csv_tuples.issubset(synapse_tuples))
+        self.assertTrue(csv_tuples.issubset(synapse_tuples))
 
     def test_number_neuron_to_neuron(self):
         """
@@ -354,7 +354,7 @@ class DataIntegrityTest(unittest.TestCase):
             if synapse.termination() == 'neuron':
                 count += 1
 
-        assertEqual(5805, count)
+        self.assertEqual(5805, count)
 
     def test_number_neuron_to_muscle(self):
         """
@@ -367,4 +367,4 @@ class DataIntegrityTest(unittest.TestCase):
             if synapse.termination() == 'muscle':
                 count += 1
 
-        assertEqual(1111, count)
+        self.assertEqual(1111, count)

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -59,6 +59,13 @@ class DataIntegrityTest(unittest.TestCase):
         net = PyOpenWorm.Worm().get_neuron_network()
         self.assertEqual(302, len(set(net.neuron_names())))
 
+    @unittest.expectedFailure
+    def test_correct_connections_number(self):
+        """ This test verifies that there are exactly 3225 connections. """
+        net = PyOpenWorm.Worm().get_neuron_network()
+        #TODO Change the number of connections when the new connectome is ready.
+        self.assertEqual(3225, len(net.synapses())
+
     def test_TH_neuropeptide_neuron_list(self):
         """
         This test verifies that the set of neurons which contain the
@@ -296,3 +303,28 @@ class DataIntegrityTest(unittest.TestCase):
         muscles = PyOpenWorm.Worm().muscles()
         for muscle_object in muscles:
             assert isinstance(muscle_object, PyOpenWorm.Cell)
+
+    @unittest.expectedFailure
+    def test_connection_content_matches(self):
+        """ This test verifies that the content of each connection matches the
+        content in the source. """
+        synapses = PyOpenWorm.Worm().get_neuron_network().synapses()
+        ignored_cells = ['hyp', 'intestine']
+        unmatched = 0
+
+        # read csv file row by row
+        with open('OpenWormData/aux_data/herm_full_edgelist.csv', 'rb') as csvfile:
+            edge_reader = csv.reader(csvfile)
+            edge_reader.next()    # skip header row
+
+            for row in edge_reader:
+                source, target, weight, syn_type = map(str.strip, row)
+                # ignore rows where source or target is 'hyp' or 'intestine'
+                if (source in ignored_cells or target in ignored_cells):
+                    continue
+                connection = PyOpenWorm.Connection(source, target, weight, syn_type)
+                # if the connection represented in the row is not in synapses, increment count of unmatched
+                if (connection not in synapses):
+                    unmatched += 1
+
+        assertEqual(0, unmatched)

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -355,3 +355,16 @@ class DataIntegrityTest(unittest.TestCase):
                 count += 1
 
         assertEqual(5805, count)
+
+    def test_number_neuron_to_muscle(self):
+        """
+        This test verifies that the worm model has exactly 1111 neuron to muscle connections.
+        """
+        synapses = PyOpenWorm.Worm().get_neuron_network().synapses()
+        count = 0
+
+        for synapse in synapses:
+            if synapse.termination() == 'muscle':
+                count += 1
+
+        assertEqual(1111, count)

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -342,3 +342,16 @@ class DataIntegrityTest(unittest.TestCase):
                 csv_tuples.add(csv_tuple)
 
         assert(csv_tuples.issubset(synapse_tuples))
+
+    def test_number_neuron_to_neuron(self):
+        """
+        This test verifies that the worm model has exactly 5805 neuron to neuron connections.
+        """
+        synapses = PyOpenWorm.Worm().get_neuron_network().synapses()
+        count = 0
+
+        for synapse in synapses:
+            if synapse.termination() == 'neuron':
+                count += 1
+
+        assertEqual(5805, count)

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -59,6 +59,7 @@ class DataIntegrityTest(unittest.TestCase):
         net = PyOpenWorm.Worm().get_neuron_network()
         self.assertEqual(302, len(set(net.neuron_names())))
 
+    @unittest.expectedFailure
     def test_correct_muscle_number(self):
         """
         This test verifies that the worm model has exactly 144 muscles.

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -346,7 +346,8 @@ class DataIntegrityTest(unittest.TestCase):
     @unittest.expectedFailure
     def test_number_neuron_to_neuron(self):
         """
-        This test verifies that the worm model has exactly 5805 neuron to neuron connections.
+        This test verifies that the worm model has exactly 5805 neuron to neuron
+        connections.
         """
         synapses = PyOpenWorm.Worm().get_neuron_network().synapses()
         count = 0
@@ -360,7 +361,8 @@ class DataIntegrityTest(unittest.TestCase):
     @unittest.expectedFailure
     def test_number_neuron_to_muscle(self):
         """
-        This test verifies that the worm model has exactly 1111 neuron to muscle connections.
+        This test verifies that the worm model has exactly 1111 neuron to muscle
+        connections.
         """
         synapses = PyOpenWorm.Worm().get_neuron_network().synapses()
         count = 0
@@ -370,3 +372,17 @@ class DataIntegrityTest(unittest.TestCase):
                 count += 1
 
         self.assertEqual(1111, count)
+
+    @unittest.expectedFailure
+    def test_correct_number_unique_neurons(self):
+        """
+        This test verifies that the worm model has exactly 300 unique neurons
+        making connections.
+        """
+        synapses = PyOpenWorm.Worm().get_neuron_network().synapses()
+        unique_neurons = {}    # set of unique neurons
+
+        for synapse in synapses:
+            unique_neurons.add(synapse.pre_cell())    # set won't count duplicates
+
+        self.assertEqual(300, len(unique_neurons))

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -316,8 +316,8 @@ class DataIntegrityTest(unittest.TestCase):
         """ This test verifies that the content of each connection matches the
         content in the source. """
         ignored_cells = ['HYP', 'INTESTINE']
-        synapse_tuples = []    # set of tuple representation of synapses
-        csv_tuples = []        # set of tuple representation of csv file
+        synapse_tuples = {}    # set of tuple representation of synapses
+        csv_tuples = {}        # set of tuple representation of csv file
 
         synapses = PyOpenWorm.Worm().get_neuron_network().synapses()
         for synapse in synapses:

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -315,7 +315,7 @@ class DataIntegrityTest(unittest.TestCase):
     def test_connection_content_matches(self):
         """ This test verifies that the content of each connection matches the
         content in the source. """
-        ignored_cells = ['HYP', 'INTESTINE']
+        ignored_cells = ['hyp', 'intestine']
         synapse_tuples = {}    # set of tuple representation of synapses
         csv_tuples = {}        # set of tuple representation of csv file
 

--- a/tests/DataIntegrityTest.py
+++ b/tests/DataIntegrityTest.py
@@ -59,13 +59,6 @@ class DataIntegrityTest(unittest.TestCase):
         net = PyOpenWorm.Worm().get_neuron_network()
         self.assertEqual(302, len(set(net.neuron_names())))
 
-    @unittest.expectedFailure
-    def test_correct_connections_number(self):
-        """ This test verifies that there are exactly 3225 connections. """
-        net = PyOpenWorm.Worm().get_neuron_network()
-        #TODO Change the number of connections when the new connectome is ready.
-        self.assertEqual(3225, len(net.synapses())
-
     def test_TH_neuropeptide_neuron_list(self):
         """
         This test verifies that the set of neurons which contain the
@@ -303,6 +296,13 @@ class DataIntegrityTest(unittest.TestCase):
         muscles = PyOpenWorm.Worm().muscles()
         for muscle_object in muscles:
             assert isinstance(muscle_object, PyOpenWorm.Cell)
+
+    @unittest.expectedFailure
+    def test_correct_connections_number(self):
+        """ This test verifies that there are exactly 3225 connections. """
+        net = PyOpenWorm.Worm().get_neuron_network()
+        #TODO Change the number of connections when the new connectome is ready.
+        self.assertEqual(3225, len(net.synapses())
 
     @unittest.expectedFailure
     def test_connection_content_matches(self):


### PR DESCRIPTION
Should fix #163 and is connected to #252 .

According to the info provided by @ahrasheed , the new tests cover the following:
- [x] there are exactly 6916 connections in total
- [x] 5805 neuron to neuron connections
- [x] 1111 neuron to muscle connections
- [x] the contents of all connection match the ones in the [csv file] (https://github.com/openworm/PyOpenWorm/blob/new_connectome/OpenWormData/aux_data/herm_full_edgelist.csv)
- [x] 300 unique neurons making connections
- [x] exactly 2 unconnected neurons: CANL, CANR
- [x] 144 muscles in total

Nothing changed for the test for the correct number of neurons (302). Just a note about the matching connections content: I essentially checked if all the connections in the csv file appear in the set returned by `Network.synapses()` (i.e., if it's a subset). I didn't check the other way around (i.e., identical sets), but let me know if I should change that test at all.

The tests have expected failure decorators at the moment, until the new connectome is merged. If any problems show up with the tests when that happens, or if anyone sees any problems at the moment, just let me know and I'll correct them.

cc @slarson @travs  