### PR TITLE
116 connection   str   to print

### DIFF
--- a/PyOpenWorm/__init__.py
+++ b/PyOpenWorm/__init__.py
@@ -57,7 +57,7 @@ Classes
 """
 
 from __future__ import print_function
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 __author__ = 'Stephen Larson'
 
 import sys

--- a/PyOpenWorm/connection.py
+++ b/PyOpenWorm/connection.py
@@ -124,3 +124,21 @@ class Connection(DataObject):
             data = tuple(x.defined_values[0].identifier().n3() for x in data)
             data = "".join(data)
             return self.make_identifier(data)
+
+    def __str__(self):
+        nom = []
+        if self.pre_cell.has_defined_value():
+            nom.append(('pre_cell', self.pre_cell.values[0]))
+        if self.post_cell.has_defined_value():
+            nom.append(('post_cell', self.post_cell.values[0]))
+        if self.syntype.has_defined_value():
+            nom.append(('syntype', self.syntype.values[0]))
+        if self.termination.has_defined_value():
+            nom.append(('termination', self.termination.values[0]))
+        if self.number.has_defined_value():
+            nom.append(('number', self.number.values[0]))
+        if self.synclass.has_defined_value():
+            nom.append(('synclass', self.synclass.values[0]))
+        return 'Connection(' + \
+               ', '.join('{}={}'.format(n[0], n[1]) for n in nom) + \
+               ')'

--- a/PyOpenWorm/dataObject.py
+++ b/PyOpenWorm/dataObject.py
@@ -80,7 +80,7 @@ class DataObject(GraphObject, DataUser):
 
     def __repr__(self):
         s = self.__class__.__name__ + "("
-        s += repr(self.idl)
+        s += 'ident=' + repr(self.idl)
         s += ")"
         return s
 

--- a/tests/DataObjectTest.py
+++ b/tests/DataObjectTest.py
@@ -49,4 +49,6 @@ class DataObjectTest(_DataTest):
         self.assertIsNotNone(u)
 
     def test_repr(self):
-        self.assertRegexpMatches(repr(DataObject(ident="http://example.com")), r"DataObject\(rdflib\.term\.URIRef\(u?[\"']http://example.com[\"']\)\)")
+        self.assertRegexpMatches(repr(DataObject(ident="http://example.com")),
+                                 r"DataObject\(ident=rdflib\.term\.URIRef\("
+                                 r"u?[\"']http://example.com[\"']\)\)")


### PR DESCRIPTION
This PR defines a `__str__` method for Connection which shows relevant info. It also updates `DataObject.__repr__` to be more precise in case of a subclass that doesn't take the identifier as the first argument to its initializer. There's a tentative version bump as well.

As originally described in #116, the example describes a `__repr__` rather than a `__str__` implementation. To actually get the behavior shown would require additional fetches to get data other than a single identifier when making a new object. 