### PR TITLE
Adding details about "question" issues to the template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,6 +9,13 @@ If this issue is intended to be a *bug report*, please fill out the following:
 
 ---
 
+If this issue is a question about the usage, behavior, or design of PyOpenWorm,
+please attach the 'question' label. For questions about behavior, you are most
+likely to get a good answer quickly if you provide a [short, self-contained
+example](http://www.sscce.org/) demonstrating the behavior.
+
+---
+
 If this issue is intended to be a *beginner issue*, please add all of the following:
 
 - [ ] Requirements are clearly specified

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/openworm/PyOpenWorm.png?branch=dev)](https://travis-ci.org/openworm/PyOpenWorm/builds)
-[![Docs](https://readthedocs.org/projects/pow-doc/badge/?version=latest)](https://pow-doc.readthedocs.io/en/latest)
-[![Stories in Ready](https://badge.waffle.io/openworm/pyopenworm.png?label=ready&title=Ready)](https://waffle.io/openworm/pyopenworm)  [![Coverage Status](https://coveralls.io/repos/github/openworm/PyOpenWorm/badge.svg?branch=dev)](https://coveralls.io/github/openworm/PyOpenWorm?branch=dev)
+[![Docs](https://readthedocs.org/projects/pyopenworm/badge/?version=latest)](https://pyopenworm.readthedocs.io/en/latest)
+[![Coverage Status](https://coveralls.io/repos/github/openworm/PyOpenWorm/badge.svg?branch=dev)](https://coveralls.io/github/openworm/PyOpenWorm?branch=dev)
 
 PyOpenWorm
 ===========
@@ -280,9 +280,20 @@ More examples can be found
 Documentation
 -------------
 
-Further documentation [is available online](http://pow-doc.readthedocs.org).
+Further documentation [is available online](http://pyopenworm.readthedocs.org).
 
-Questions?
-----------
-[Join the Slack chat](https://openworm.slack.com/messages/C02EPNMP1/) for
-clarification, to ask questions, or just to say, 'Hi'.
+Contributing
+------------
+We happily welcome pull requests and [bug
+reports](https://github.com/openworm/PyOpenWorm/issues/new). If, you are not
+sure how you can contribute, fill out this (short)
+[form](https://docs.google.com/forms/d/e/1FAIpQLSdzVilyRX3z9e0PeAoQdXhBDiNXp2ugqpnT536xA2iQbLNymQ/viewform?formkey=dC1CUDQtTV82MEJJcjY0NjdCcHpYdmc6MQ#gid=0),
+and you'll receive an invite to our Slack chat where you can initiate more
+in-depth conversations.
+
+
+Questions/Concerns?
+-------------------
+You can ask questions, leave bug reports, or propose features on [our issue
+tracker](https://github.com/openworm/PyOpenWorm/issues/new).
+


### PR DESCRIPTION
- Redirecting questions about POW to the issue tracker (the Slack link
  was not useful for new contributors anyway)
- Adding the contributor form link to the README