### PR TITLE
Passing DataSource objects to DSDL (#409)

### DIFF
--- a/PyOpenWorm/bittorrent.py
+++ b/PyOpenWorm/bittorrent.py
@@ -1,0 +1,7 @@
+from .datasource_loader import DataSourceDirLoader
+
+
+class BitTorrentDataSourceDirLoader(DataSourceDirLoader):
+
+    def load(self, data_source):
+        pass

--- a/tests/DataSourceLoaderTest.py
+++ b/tests/DataSourceLoaderTest.py
@@ -13,7 +13,7 @@ class DataSourceDirLoaderTest(unittest.TestCase):
         with TemporaryDirectory() as d:
             reldir = relpath(d, getcwd())
             cut = DataSourceDirLoader(reldir)
-            self.assertEqual(d, cut._basedir)
+            self.assertEqual(d, cut.base_directory)
 
     def test_load_no_ident(self):
         class A(DataSourceDirLoader):


### PR DESCRIPTION
- Makes it more convenient for loaders to get at attached data
- Also, initializing DSDLs earlier so we can more easily configure them within POW